### PR TITLE
Add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/coverage-report.yml"
+
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/coverage-report.yml"
+      - "src/**"
+      - "test/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ csharp ]
+
+    permissions:
+      security-events: write
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [csharp]
+        language: ["javascript"]
 
     permissions:
       security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - ".github/workflows/coverage-report.yml"
+      - ".github/workflows/codeql-analysis.yml"
 
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - ".github/workflows/coverage-report.yml"
+      - ".github/workflows/codeql-analysis.yml"
       - "src/**"
       - "test/**"
 
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ csharp ]
+        language: [csharp]
 
     permissions:
       security-events: write


### PR DESCRIPTION
# Description

This pull request adds a CodeQL workflow for analyzing the Node.js codebase to identify potential security vulnerabilities. The workflow is triggered on `push` or `pull_request` events to the `main` branch, specifically for changes in the `.github/workflows/coverage-report.yml`, `src/`, and `test/` directories. This setup ensures continuous code analysis and improves security during the development lifecycle.

## Approach

The CodeQL workflow leverages GitHub's built-in CodeQL action to automate code analysis for Node.js (JavaScript/TypeScript). It performs the following key steps:
1. **Checkout the repository** to access the code.
2. **Initialize CodeQL** for JavaScript/TypeScript.
3. **Autobuild and analyze** the code using the CodeQL action.

This approach ensures that the code is scanned for security vulnerabilities on every push and pull request, giving quick feedback to developers.

## Open Questions and Pre-Merge TODOs

- [ ] Confirm if we need to add TypeScript or other languages in the matrix (currently set up for Node.js).
- [ ] Check if we should include additional paths for triggering the workflow.
  
## Learning

In setting up this workflow, I researched the CodeQL integration for Node.js projects and followed GitHub's recommended practices for security scanning:
- [GitHub CodeQL Documentation](https://docs.github.com/en/code-security/code-scanning/using-codeql/codeql-overview)