### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Envilder requires two arguments:
 
     ```json
     {
-      "NEXT_PUBLIC_CREDENTIAL_EMAIL": "/path/to/ssm/email",
-      "NEXT_PUBLIC_CREDENTIAL_PASSWORD": "/path/to/ssm/password"
+      "SECRET_TOKEN": "/path/to/ssm/token",
+      "SECRET_KEY": "/path/to/ssm/password"
     }
     ```
 
@@ -72,8 +72,8 @@ Envilder requires two arguments:
 # 📂 Sample `.env` Output
 
 ```makefile
-NEXT_PUBLIC_CREDENTIAL_EMAIL=mockedEmail@example.com
-NEXT_PUBLIC_CREDENTIAL_PASSWORD=mockedPassword
+SECRET_TOKEN=mockedEmail@example.com
+SECRET_KEY=mockedPassword
 ```
 
 # 🧪 Running Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envilder",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A CLI tool to generate .env files from AWS SSM parameters",
   "exports": {
     ".": {


### PR DESCRIPTION
# Description

This PR addresses the issue of exposing sensitive data through the use of `NEXT_PUBLIC_` prefixes in environment variables. 

## Approach

We have removed the `NEXT_PUBLIC_` prefix from sensitive environment variables to prevent unintentional exposure in the client-side code, thereby enhancing security.

## Open Questions and Pre-Merge TODOs

- [ ] Ensure all sensitive variables are securely handled.
  
## Learning

This change aligns with best practices for environment variable management and helps in maintaining application security.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated examples and usage instructions for the `Envilder` CLI tool in the `README.md`.
	- Revised environment variable mappings to reflect new parameters: `SECRET_TOKEN` and `SECRET_KEY`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->