### PR TITLE
chore(package-lock): update brace-expansion to version 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3710,9 +3710,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "envilder",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A CLI that securely centralizes your environment variables from AWS SSM as a single source of truth",
   "main": "./lib/Cli.js",
   "bin": {


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR releases version 0.5.5 of envilder with improvements to code organization, documentation, and test reliability.

## Key Changes

### Code Organization
- Restructured `EnvilderBuilder` by moving it from `domain` to `application/builders` directory
- Updated import paths across the codebase for better organization
- Enhanced code architecture alignment with domain-driven design principles

### Bug Fixes
- Fixed glob pattern and path handling in test cleanup functions
- Corrected file path resolution in end-to-end tests
- Improved error handling during test file deletions

### Documentation
- Extensively updated README with clearer structure and table of contents
- Added feature status table to clarify implemented vs planned features
- Simplified installation and usage instructions
- Revamped pull request template for a better contributor experience

### Security
- Maintains the `brace-expansion` update (v2.0.2) introduced in v0.5.4
- Continues to address the low-severity Regular Expression Denial of Service (ReDoS) vulnerability

## Notes for reviewer
Please verify the documentation improvements and confirm that the builder restructuring doesn't impact any functionality.