### PR TITLE
fix(ci): use NuGet flat container API for version check

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -45,7 +45,7 @@ jobs:
         id: version-check
         run: |
           CURRENT_VERSION=$(grep -oP '<Version>\K[^<]+' Envilder.csproj)
-          PUBLISHED_VERSION=$(dotnet package search Envilder --source https://api.nuget.org/v3/index.json --exact-match --format json 2>/dev/null | jq -r '.searchResult[0].packages[0].latestVersion // "0.0.0"')
+          PUBLISHED_VERSION=$(curl -sf "https://api.nuget.org/v3-flatcontainer/envilder/index.json" | jq -r '.versions[-1] // "0.0.0"' || echo "0.0.0")
 
           echo "Current version: $CURRENT_VERSION, Published version: $PUBLISHED_VERSION"
 

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -45,7 +45,19 @@ jobs:
         id: version-check
         run: |
           CURRENT_VERSION=$(grep -oP '<Version>\K[^<]+' Envilder.csproj)
-          PUBLISHED_VERSION=$(curl -sf "https://api.nuget.org/v3-flatcontainer/envilder/index.json" | jq -r '.versions[-1] // "0.0.0"' || echo "0.0.0")
+
+          HTTP_CODE=$(curl -s -o /tmp/nuget-response.json -w '%{http_code}' \
+            "https://api.nuget.org/v3-flatcontainer/envilder/index.json")
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            PUBLISHED_VERSION=$(jq -r '.versions[-1] // "0.0.0"' /tmp/nuget-response.json)
+          elif [ "$HTTP_CODE" = "404" ]; then
+            echo "Package not found on NuGet — first publish."
+            PUBLISHED_VERSION="0.0.0"
+          else
+            echo "::error::NuGet API returned unexpected HTTP $HTTP_CODE"
+            exit 1
+          fi
 
           echo "Current version: $CURRENT_VERSION, Published version: $PUBLISHED_VERSION"
 


### PR DESCRIPTION
## Description
Fix publish-nuget workflow failing when there's no new version to publish.

## Type of Change
- [x] Bug fix

## Changes Made
- Replace `dotnet package search` with `curl` to NuGet flat container API (`/v3-flatcontainer/envilder/index.json`)
- Add proper `|| echo "0.0.0"` fallback so any failure (package not found, network error) defaults gracefully

## Root Cause
The `dotnet package search ... | jq ...` pipeline had no failure fallback. With GitHub Actions' default `set -eo pipefail`, if `dotnet package search` exits non-zero (package not yet published, CLI output format change, transient error), the entire step fails — aborting the workflow instead of setting `version_changed=false` and skipping publish.

## Evidence
- Failed run: https://github.com/macalbert/envilder/actions/runs/24428790856/job/71368535093
- NPM and PyPI workflows already use proper `|| echo "0.0.0"` fallback patterns

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/macalbert/envilder/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
