### PR TITLE
fix(e2e): use separate env file for GHA tests

### DIFF
--- a/e2e/gha.test.ts
+++ b/e2e/gha.test.ts
@@ -47,7 +47,7 @@ const LOWKEY_VAULT_IMAGE = 'nagyesta/lowkey-vault:7.1.32';
 const LOWKEY_VAULT_PORT = 8443;
 
 describe('GitHub Action (E2E)', () => {
-  const envFilePath = join(rootDir, 'e2e', 'sample', 'cli-validation.env');
+  const envFilePath = join(rootDir, 'e2e', 'sample', 'gha-validation.env');
   const mapFilePath = join(rootDir, 'e2e', 'sample', 'param-map.json');
   const mapFileWithConfigPath = join(
     rootDir,


### PR DESCRIPTION
## Description
Give the GHA E2E test suite its own output env file to avoid collisions with the CLI suite.

## Type of Change
- [x] Bug fix

## Changes Made
- Rename GHA test output from `cli-validation.env` → `gha-validation.env` in `e2e/gha.test.ts`

## Root Cause
Both CLI and GHA E2E suites wrote to the same `cli-validation.env` file, which can cause file collisions when tests run in parallel.

## Checklist
- [x] Code follows project conventions
- [x] No breaking changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/macalbert/envilder/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
