### PR TITLE
chore(ci): upgrade setup-python to v6 and setup-uv to v7

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -175,7 +175,7 @@ jobs:
           python-version: "3.12"
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: 🛠️ Setup Node.js (for extract-test-stats)
         uses: actions/setup-node@v6

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -170,12 +170,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🐍 Setup Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: 🛠️ Setup Node.js (for extract-test-stats)
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,12 +31,12 @@ jobs:
           fetch-depth: 0
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: 👑 Detect version bump
         id: version-check

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.13"
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: 👑 Detect version bump
         id: version-check

--- a/.github/workflows/tests-python-sdk.yml
+++ b/.github/workflows/tests-python-sdk.yml
@@ -39,12 +39,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 🐍 Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: 🪙 Collect Coins (Configure AWS credentials)
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/tests-python-sdk.yml
+++ b/.github/workflows/tests-python-sdk.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: 📦 Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: 🪙 Collect Coins (Configure AWS credentials)
         uses: aws-actions/configure-aws-credentials@v6

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@
 [![npm version](https://img.shields.io/npm/v/envilder.svg)](https://www.npmjs.com/package/envilder)
 [![npm downloads](https://img.shields.io/npm/dm/envilder.svg)](https://npmcharts.com/compare/envilder)
 [![CI Tests](https://github.com/macalbert/envilder/actions/workflows/tests.yml/badge.svg)](https://github.com/macalbert/envilder/actions/workflows/tests.yml)
-[![Coverage](https://macalbert.github.io/envilder/badge_combined.svg)](https://macalbert.github.io/envilder/)
+[![Overall Coverage](https://macalbert.github.io/envilder/badge_combined.svg)](https://macalbert.github.io/envilder/)
 
-[![Core](https://macalbert.github.io/envilder/core/badge_named.svg)](https://macalbert.github.io/envilder/core/index.html)
-[![.NET](https://macalbert.github.io/envilder/dotnet/badge_named.svg)](https://macalbert.github.io/envilder/dotnet/index.html)
-[![Python](https://macalbert.github.io/envilder/python/badge_named.svg)](https://macalbert.github.io/envilder/python/index.html)
-[![IaC](https://macalbert.github.io/envilder/iac/badge_named.svg)](https://macalbert.github.io/envilder/iac/index.html)
+[![Core Coverage](https://macalbert.github.io/envilder/core/badge_named.svg)](https://macalbert.github.io/envilder/core/index.html)
+[![.NET Coverage](https://macalbert.github.io/envilder/dotnet/badge_named.svg)](https://macalbert.github.io/envilder/dotnet/index.html)
+[![Python Coverage](https://macalbert.github.io/envilder/python/badge_named.svg)](https://macalbert.github.io/envilder/python/index.html)
+[![IaC Coverage](https://macalbert.github.io/envilder/iac/badge_named.svg)](https://macalbert.github.io/envilder/iac/index.html)
 
 [![Known Vulnerabilities](https://snyk.io/test/github/macalbert/envilder/badge.svg)](https://snyk.io/test/github/macalbert/envilder)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@
 [![npm version](https://img.shields.io/npm/v/envilder.svg)](https://www.npmjs.com/package/envilder)
 [![npm downloads](https://img.shields.io/npm/dm/envilder.svg)](https://npmcharts.com/compare/envilder)
 [![CI Tests](https://github.com/macalbert/envilder/actions/workflows/tests.yml/badge.svg)](https://github.com/macalbert/envilder/actions/workflows/tests.yml)
-[![Coverage Report](https://img.shields.io/badge/coverage-report-green.svg)](https://macalbert.github.io/envilder/)
+[![Coverage](https://macalbert.github.io/envilder/badge_combined.svg)](https://macalbert.github.io/envilder/)
+
+[![Core](https://macalbert.github.io/envilder/core/badge_named.svg)](https://macalbert.github.io/envilder/core/index.html)
+[![.NET](https://macalbert.github.io/envilder/dotnet/badge_named.svg)](https://macalbert.github.io/envilder/dotnet/index.html)
+[![Python](https://macalbert.github.io/envilder/python/badge_named.svg)](https://macalbert.github.io/envilder/python/index.html)
+[![IaC](https://macalbert.github.io/envilder/iac/badge_named.svg)](https://macalbert.github.io/envilder/iac/index.html)
+
 [![Known Vulnerabilities](https://snyk.io/test/github/macalbert/envilder/badge.svg)](https://snyk.io/test/github/macalbert/envilder)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions dependencies to fix Node.js 20 deprecation warnings
and adds live coverage badges from GitHub Pages to the root README.

## Changes

### CI workflows
- `actions/setup-python` v5 → **v6** (Node.js 24 compatible)
- `astral-sh/setup-uv` v6 → **v7** (latest available major tag; `v8.0.0` release exists but floating `v8` tag not yet published)
- Affected: `publish-pypi.yml`, `tests-python-sdk.yml`, `coverage-report.yml`

### README
- Replaced static shields.io coverage badge with live SVG from GitHub Pages
- Added per-stack badges (Core, .NET, Python, IaC) linking to individual reports

## Testing

- [x] No logic changes — workflow action version bumps only
- [x] README badge URLs verified (200 OK)