### PR TITLE
fix(sdk): delegate default AWS region resolution to native SDKs

### DIFF
--- a/docs/changelogs/sdk-dotnet.md
+++ b/docs/changelogs/sdk-dotnet.md
@@ -7,6 +7,9 @@
   plain `AmazonSimpleSystemsManagementClient()` which uses the full AWS SDK resolution chain
   (env vars → `~/.aws/config` → instance metadata), correctly picking up the default config
   file settings
+* **Respect `AWS_SHARED_CREDENTIALS_FILE` for profile resolution** — `CredentialProfileStoreChain`
+  now receives the credentials file path from the `AWS_SHARED_CREDENTIALS_FILE` environment
+  variable, fixing profile discovery when credentials are stored at non-default locations
 
 ---
 

--- a/docs/changelogs/sdk-dotnet.md
+++ b/docs/changelogs/sdk-dotnet.md
@@ -7,9 +7,11 @@
   plain `AmazonSimpleSystemsManagementClient()` which uses the full AWS SDK resolution chain
   (env vars → `~/.aws/config` → instance metadata), correctly picking up the default config
   file settings
+  ([#166](https://github.com/macalbert/envilder/pull/166))
 * **Respect `AWS_SHARED_CREDENTIALS_FILE` for profile resolution** — `CredentialProfileStoreChain`
   now receives the credentials file path from the `AWS_SHARED_CREDENTIALS_FILE` environment
   variable, fixing profile discovery when credentials are stored at non-default locations
+  ([#166](https://github.com/macalbert/envilder/pull/166))
 
 ---
 

--- a/docs/changelogs/sdk-dotnet.md
+++ b/docs/changelogs/sdk-dotnet.md
@@ -1,3 +1,15 @@
+## [0.1.1] - 2026-04-18
+
+### Fixed
+
+* **Delegate default AWS region resolution to the AWS SDK** — When no profile is set, the
+  factory no longer manually resolves the region via `ResolveRegion()`. Instead it creates a
+  plain `AmazonSimpleSystemsManagementClient()` which uses the full AWS SDK resolution chain
+  (env vars → `~/.aws/config` → instance metadata), correctly picking up the default config
+  file settings
+
+---
+
 ## [0.1.0] - 2026-04-09
 
 ### Added

--- a/docs/changelogs/sdk-python.md
+++ b/docs/changelogs/sdk-python.md
@@ -6,6 +6,7 @@
   no longer manually resolves the region from environment variables. Instead it creates a plain
   `boto3.Session()` which uses the full AWS SDK resolution chain (env vars → `~/.aws/config` →
   instance metadata), correctly picking up the default config file settings
+  ([#166](https://github.com/macalbert/envilder/pull/166))
 
 ---
 

--- a/docs/changelogs/sdk-python.md
+++ b/docs/changelogs/sdk-python.md
@@ -1,3 +1,14 @@
+## [0.3.2] - 2026-04-18
+
+### Fixed
+
+* **Delegate default AWS region resolution to boto3** — When no profile is set, the factory
+  no longer manually resolves the region from environment variables. Instead it creates a plain
+  `boto3.Session()` which uses the full AWS SDK resolution chain (env vars → `~/.aws/config` →
+  instance metadata), correctly picking up the default config file settings
+
+---
+
 ## [0.3.1] - 2026-04-17
 
 ### Fixed

--- a/src/sdks/dotnet/Envilder.csproj
+++ b/src/sdks/dotnet/Envilder.csproj
@@ -5,7 +5,7 @@
     <PackageId>Envilder</PackageId>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <Authors>macalbert</Authors>
     <Description>Securely load environment variables from AWS SSM Parameter Store or Azure Key Vault directly into your .NET application configuration and DI container. Zero vendor lock-in.</Description>
     <PackageTags>secrets;environment-variables;aws-ssm;azure-keyvault;configuration;dependency-injection</PackageTags>

--- a/src/sdks/dotnet/Infrastructure/SecretProviderFactory.cs
+++ b/src/sdks/dotnet/Infrastructure/SecretProviderFactory.cs
@@ -65,7 +65,8 @@ public static class SecretProviderFactory
 
         if (!string.IsNullOrWhiteSpace(profile))
         {
-            var chain = new CredentialProfileStoreChain();
+            var profilesLocation = Environment.GetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE");
+            var chain = new CredentialProfileStoreChain(profilesLocation);
             if (chain.TryGetAWSCredentials(profile, out var credentials))
             {
                 var region = ResolveProfileRegion(chain, profile!);

--- a/src/sdks/dotnet/Infrastructure/SecretProviderFactory.cs
+++ b/src/sdks/dotnet/Infrastructure/SecretProviderFactory.cs
@@ -76,10 +76,7 @@ public static class SecretProviderFactory
                 $"AWS profile '{profile}' was not found in the credential store.");
         }
 
-        return new(new AmazonSimpleSystemsManagementClient(new AmazonSimpleSystemsManagementConfig
-        {
-            RegionEndpoint = ResolveRegion(),
-        }));
+        return new(new AmazonSimpleSystemsManagementClient());
     }
 
     private static RegionEndpoint ResolveProfileRegion(CredentialProfileStoreChain chain, string profile)

--- a/src/sdks/python/envilder/infrastructure/secret_provider_factory.py
+++ b/src/sdks/python/envilder/infrastructure/secret_provider_factory.py
@@ -68,27 +68,21 @@ def _create_aws_provider(
         options.profile if options and options.profile else config.profile
     )
 
-    if profile:
-        try:
-            region = _resolve_region_from_env()
-            session = (
-                boto3.Session(profile_name=profile, region_name=region)
-                if region
-                else boto3.Session(profile_name=profile)
-            )
-            ssm_client = session.client("ssm")
-        except Exception as e:
-            raise ValueError(
-                f"Failed to create AWS session with profile '{profile}': {e}"
-            ) from e
-    else:
-        region = _resolve_region_from_env()
-        session = (
-            boto3.Session(region_name=region) if region else boto3.Session()
-        )
-        ssm_client = session.client("ssm")
+    if not profile:
+        session = boto3.Session()
+        return AwsSsmSecretProvider(session.client("ssm"))
 
-    return AwsSsmSecretProvider(ssm_client)
+    try:
+        region = _resolve_region_from_env()
+        session = boto3.Session(
+            profile_name=profile,
+            region_name=region,
+        )
+        return AwsSsmSecretProvider(session.client("ssm"))
+    except Exception as e:
+        raise ValueError(
+            f"Failed to create AWS session with profile '{profile}': {e}"
+        ) from e
 
 
 def _resolve_region_from_env() -> str | None:

--- a/src/sdks/python/pyproject.toml
+++ b/src/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "envilder"
-version = "0.3.1"
+version = "0.3.2"
 description = "Securely load environment variables from AWS SSM Parameter Store or Azure Key Vault."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/sdks/python/uv.lock
+++ b/src/sdks/python/uv.lock
@@ -441,7 +441,7 @@ wheels = [
 
 [[package]]
 name = "envilder"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },

--- a/tests/sdks/dotnet/Infrastructure/SecretProviderFactoryAcceptanceTests.cs
+++ b/tests/sdks/dotnet/Infrastructure/SecretProviderFactoryAcceptanceTests.cs
@@ -1,0 +1,144 @@
+namespace Envilder.Tests.Infrastructure;
+
+using Amazon.SimpleSystemsManagement;
+using AwesomeAssertions;
+using Envilder.Domain;
+using Envilder.Infrastructure;
+using Envilder.Tests.Fixtures;
+
+[Collection(nameof(ContainersCollection))]
+public class SecretProviderFactoryAcceptanceTests
+{
+    private readonly LocalStackFixture _localStack;
+
+    public SecretProviderFactoryAcceptanceTests(LocalStackFixture localStack)
+    {
+        _localStack = localStack;
+    }
+
+    [Fact(Timeout = CancellationTokenForTest.DefaultTimeout)]
+    public async Task Should_ResolveSecret_When_FactoryCreatesProviderWithoutProfile()
+    {
+        // Arrange
+        await _localStack.SsmClient.PutParameterAsync(new()
+        {
+            Name = "/Test/FactoryNoProfile",
+            Value = "factory-no-profile-secret",
+            Type = ParameterType.SecureString,
+            Overwrite = true,
+        });
+
+        var envVarsToOverride = new[]
+        {
+            "AWS_ENDPOINT_URL", "AWS_SERVICE_URL",
+            "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+            "AWS_DEFAULT_REGION", "AWS_REGION",
+        };
+        var originalValues = envVarsToOverride
+            .Select(v => (Name: v, Value: Environment.GetEnvironmentVariable(v)))
+            .ToArray();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", _localStack.ServiceUrl);
+            Environment.SetEnvironmentVariable("AWS_SERVICE_URL", _localStack.ServiceUrl);
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", "test");
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", "test");
+            Environment.SetEnvironmentVariable("AWS_DEFAULT_REGION", "us-east-1");
+
+            var config = new MapFileConfig { Provider = SecretProviderType.Aws };
+            var sut = SecretProviderFactory.Create(config);
+
+            // Act
+            var actual = await sut.GetSecretAsync("/Test/FactoryNoProfile");
+
+            // Assert
+            actual.Should().Be("factory-no-profile-secret");
+        }
+        finally
+        {
+            foreach (var (name, value) in originalValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
+
+    [Fact(Timeout = CancellationTokenForTest.DefaultTimeout)]
+    public async Task Should_ResolveSecret_When_FactoryCreatesProviderWithProfile()
+    {
+        // Arrange
+        await _localStack.SsmClient.PutParameterAsync(new()
+        {
+            Name = "/Test/FactoryWithProfile",
+            Value = "factory-profile-secret",
+            Type = ParameterType.SecureString,
+            Overwrite = true,
+        });
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"envilder-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        var configFilePath = Path.Combine(tempDir, "config");
+        var credentialsFilePath = Path.Combine(tempDir, "credentials");
+
+        await File.WriteAllTextAsync(configFilePath,
+            $"""
+            [profile localstack-test]
+            region = us-east-1
+            endpoint_url = {_localStack.ServiceUrl}
+            """);
+
+        await File.WriteAllTextAsync(credentialsFilePath,
+            """
+            [localstack-test]
+            aws_access_key_id = test
+            aws_secret_access_key = test
+            """);
+
+        var envVarsToOverride = new[]
+        {
+            "AWS_CONFIG_FILE", "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_ENDPOINT_URL", "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION",
+            "AWS_REGION", "AWS_PROFILE",
+        };
+        var originalValues = envVarsToOverride
+            .Select(v => (Name: v, Value: Environment.GetEnvironmentVariable(v)))
+            .ToArray();
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AWS_CONFIG_FILE", configFilePath);
+            Environment.SetEnvironmentVariable("AWS_SHARED_CREDENTIALS_FILE", credentialsFilePath);
+            Environment.SetEnvironmentVariable("AWS_ENDPOINT_URL", _localStack.ServiceUrl);
+            Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", null);
+            Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", null);
+            Environment.SetEnvironmentVariable("AWS_DEFAULT_REGION", null);
+            Environment.SetEnvironmentVariable("AWS_REGION", null);
+            Environment.SetEnvironmentVariable("AWS_PROFILE", null);
+
+            var config = new MapFileConfig
+            {
+                Provider = SecretProviderType.Aws,
+                Profile = "localstack-test",
+            };
+            var sut = SecretProviderFactory.Create(config);
+
+            // Act
+            var actual = await sut.GetSecretAsync("/Test/FactoryWithProfile");
+
+            // Assert
+            actual.Should().Be("factory-profile-secret");
+        }
+        finally
+        {
+            foreach (var (name, value) in originalValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/tests/sdks/python/fixtures/localstack_fixture.py
+++ b/tests/sdks/python/fixtures/localstack_fixture.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import shutil
+import tempfile
+from pathlib import Path
 from typing import Generator
 
 import pytest
@@ -9,6 +13,32 @@ from envilder.infrastructure.aws.aws_ssm_secret_provider import (
 from mypy_boto3_ssm import SSMClient
 
 from containers.localstack_container import LocalStackContainer
+
+_ENV_KEYS = [
+    "AWS_ENDPOINT_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_DEFAULT_REGION",
+]
+
+_PROFILE_ENV_KEYS = [
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_ENDPOINT_URL",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+    "AWS_PROFILE",
+]
+
+
+def _restore_env(originals: dict[str, str | None]) -> None:
+    for key, value in originals.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
 
 
 @pytest.fixture(scope="session")
@@ -28,3 +58,55 @@ def aws_provider(
     localstack_container: LocalStackContainer,
 ) -> AwsSsmSecretProvider:
     return localstack_container.create_provider()
+
+
+@pytest.fixture
+def aws_env_for_factory(
+    localstack_container: LocalStackContainer,
+) -> Generator[None, None, None]:
+    originals = {k: os.environ.get(k) for k in _ENV_KEYS}
+    os.environ["AWS_ENDPOINT_URL"] = localstack_container.get_endpoint_url()
+    os.environ["AWS_ACCESS_KEY_ID"] = "test"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    yield
+    _restore_env(originals)
+
+
+@pytest.fixture
+def aws_env_with_profile_for_factory(
+    localstack_container: LocalStackContainer,
+) -> Generator[None, None, None]:
+    originals = {k: os.environ.get(k) for k in _PROFILE_ENV_KEYS}
+    tmp_dir = tempfile.mkdtemp()
+    config_path = Path(tmp_dir) / "config"
+    credentials_path = Path(tmp_dir) / "credentials"
+
+    endpoint = localstack_container.get_endpoint_url()
+    config_path.write_text(
+        f"[profile localstack-test]\n"
+        f"region = us-east-1\n"
+        f"endpoint_url = {endpoint}\n"
+    )
+    credentials_path.write_text(
+        "[localstack-test]\n"
+        "aws_access_key_id = test\n"
+        "aws_secret_access_key = test\n"
+    )
+
+    os.environ["AWS_CONFIG_FILE"] = str(config_path)
+    os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(credentials_path)
+    os.environ["AWS_ENDPOINT_URL"] = endpoint
+    for key in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_DEFAULT_REGION",
+        "AWS_REGION",
+        "AWS_PROFILE",
+    ):
+        os.environ.pop(key, None)
+
+    yield
+
+    _restore_env(originals)
+    shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/sdks/python/infrastructure/test_secret_provider_factory_acceptance.py
+++ b/tests/sdks/python/infrastructure/test_secret_provider_factory_acceptance.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+from envilder.domain.map_file_config import MapFileConfig
+from envilder.domain.secret_provider_type import SecretProviderType
+from envilder.infrastructure.secret_provider_factory import (
+    SecretProviderFactory,
+)
+
+pytestmark = pytest.mark.acceptance
+
+
+class TestSecretProviderFactoryAcceptance:
+    def Should_ResolveSecret_When_FactoryCreatesProviderWithoutProfile(
+        self,
+        ssm_client,
+        aws_env_for_factory,
+    ) -> None:
+        # Arrange
+        ssm_client.put_parameter(
+            Name="/Test/FactoryNoProfile",
+            Value="factory-no-profile-secret",
+            Type="SecureString",
+            Overwrite=True,
+        )
+        config = MapFileConfig(provider=SecretProviderType.AWS)
+        sut = SecretProviderFactory.create(config)
+
+        # Act
+        actual = sut.get_secret("/Test/FactoryNoProfile")
+
+        # Assert
+        assert actual == "factory-no-profile-secret"
+
+    def Should_ResolveSecret_When_FactoryCreatesProviderWithProfile(
+        self,
+        ssm_client,
+        aws_env_with_profile_for_factory,
+    ) -> None:
+        # Arrange
+        ssm_client.put_parameter(
+            Name="/Test/FactoryWithProfile",
+            Value="factory-profile-secret",
+            Type="SecureString",
+            Overwrite=True,
+        )
+        config = MapFileConfig(
+            provider=SecretProviderType.AWS,
+            profile="localstack-test",
+        )
+        sut = SecretProviderFactory.create(config)
+
+        # Act
+        actual = sut.get_secret("/Test/FactoryWithProfile")
+
+        # Assert
+        assert actual == "factory-profile-secret"


### PR DESCRIPTION
## Description

When no AWS profile is set, both Python and .NET SDKs were manually resolving the region from environment variables (`AWS_REGION` / `AWS_DEFAULT_REGION`), bypassing the full AWS SDK resolution chain. This meant the default region from `~/.aws/config` was ignored.

## Type of Change

- [x] Bug fix

## Changes Made

### Python SDK (`0.3.1` → `0.3.2`)
- `SecretProviderFactory` now creates a plain `boto3.Session()` when no profile is set, delegating region resolution entirely to boto3's built-in chain (env vars → `~/.aws/config` → instance metadata)
- Refactored `_create_aws_provider` to use early return, removing nested if/else blocks

### .NET SDK (`0.1.0` → `0.1.1`)
- `SecretProviderFactory` now creates a plain `AmazonSimpleSystemsManagementClient()` when no profile is set, delegating region resolution entirely to the AWS SDK's built-in chain
- Removed manual `ResolveRegion()` call in the default (no-profile) path

## Checklist

- [x] Code follows project conventions
- [x] Changelogs updated
- [x] Version bumped (Python 0.3.2, .NET 0.1.1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/macalbert/envilder/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS region resolution to properly delegate to AWS SDK's default chain (environment variables, configuration files, instance metadata) when no profile is configured.

* **Chores**
  * Updated .NET SDK to version 0.1.1
  * Updated Python SDK to version 0.3.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->