### PR TITLE
docs(architecture): add ADR-0008 map-file schema specification

### DIFF
--- a/.github/skills/common-architecture-decisions/SKILL.md
+++ b/.github/skills/common-architecture-decisions/SKILL.md
@@ -34,7 +34,7 @@ behind tooling choices and architectural patterns before proposing changes.
 | [ADR-0005](../../../docs/architecture/adr/0005-sdk-integration-tiers.md) | SDK Integration Tiers | All SDKs | Three tiers (Facade, Builder, Framework); Tier 3 separate package; .NET exception; community-driven |
 | [ADR-0006](../../../docs/architecture/adr/0006-monorepo-structure.md) | Monorepo Structure | All components | Single repo, independent releases per component via version-bump detection, no orchestrator |
 | [ADR-0007](../../../docs/architecture/adr/0007-trunk-based-development.md) | Trunk-Based Development | All components | Single main branch, short-lived feature branches, squash merge, feature flags for incomplete work |
-| [ADR-0008](../../../docs/architecture/adr/0008-map-file-schema.md) | Map-File Schema Specification | All components | JSON Schema v1, `$` prefix reserved, `$config` strict fields, `file` provider for testing, `EnvilderOptions.FromFile` |
+| [ADR-0008](../../../docs/architecture/adr/0008-map-file-schema.md) | Map-File Schema Specification | All components | JSON Schema v1, `$` prefix reserved, `$config` strict fields, `file` provider for testing (planned), `EnvilderOptions.FromFile` (planned) |
 
 ## Quick Reference: Test Doubles per Stack
 

--- a/.github/skills/common-architecture-decisions/SKILL.md
+++ b/.github/skills/common-architecture-decisions/SKILL.md
@@ -31,6 +31,10 @@ behind tooling choices and architectural patterns before proposing changes.
 | [ADR-0002](../../../docs/architecture/adr/0002-test-tooling-per-stack.md) | Test Tooling per Stack | All stacks | Vitest (TS), xUnit+NSubstitute+AwesomeAssertions (NET), pytest+unittest.mock (Py) |
 | [ADR-0003](../../../docs/architecture/adr/0003-sdk-architecture-pattern.md) | SDK Architecture Pattern | All SDKs | Three-layer (Domain→App→Infra), no DI framework, facade as primary API, internal factory |
 | [ADR-0004](../../../docs/architecture/adr/0004-code-quality-tooling.md) | Code Quality and Formatting | All stacks | Biome (TS), dotnet format (.NET), black+isort (Py); Secretlint for credentials |
+| [ADR-0005](../../../docs/architecture/adr/0005-sdk-integration-tiers.md) | SDK Integration Tiers | All SDKs | Three tiers (Facade, Builder, Framework); Tier 3 separate package; .NET exception; community-driven |
+| [ADR-0006](../../../docs/architecture/adr/0006-monorepo-structure.md) | Monorepo Structure | All components | Single repo, independent releases per component via tags, no orchestrator |
+| [ADR-0007](../../../docs/architecture/adr/0007-trunk-based-development.md) | Trunk-Based Development | All components | Single main branch, short-lived feature branches, squash merge, feature flags for incomplete work |
+| [ADR-0008](../../../docs/architecture/adr/0008-map-file-schema.md) | Map-File Schema Specification | All components | JSON Schema v1, `$` prefix reserved, `$config` strict fields, `file` provider for testing, `EnvilderOptions.FromFile` |
 
 ## Quick Reference: Test Doubles per Stack
 

--- a/docs/architecture/adr/0008-map-file-schema.md
+++ b/docs/architecture/adr/0008-map-file-schema.md
@@ -122,6 +122,10 @@ Values are opaque identifiers interpreted by the provider:
 The `file` provider enables testing without cloud infrastructure. It reads an
 `.env` file and resolves mappings by key lookup.
 
+> **Note:** The `file` provider and the `EnvilderOptions.FromFile` /
+> `WithOverride` APIs described below are **proposed** — not yet implemented in
+> any SDK. The examples show the target API design for implementation.
+
 Consumers activate it via:
 
 **A) Map file (dedicated test config):**

--- a/docs/architecture/adr/0008-map-file-schema.md
+++ b/docs/architecture/adr/0008-map-file-schema.md
@@ -86,7 +86,7 @@ rejected to catch typos.
 A map file targets a single provider and a single environment. Multi-provider
 and multi-environment setups use separate files:
 
-```
+```txt
 param-map.prod.json      → $config.provider: "aws"
 param-map.staging.json   → $config.provider: "aws", different paths
 param-map.dev.json       → $config.provider: "file"

--- a/docs/architecture/adr/0008-map-file-schema.md
+++ b/docs/architecture/adr/0008-map-file-schema.md
@@ -52,7 +52,12 @@ The root object contains exactly two categories of keys:
 | `$schema` | string (URI) | Optional. Standard JSON Schema reference for IDE autocomplete |
 | `$config` | object | Optional. Provider configuration and file metadata |
 | Any key starting with `$` | — | Reserved. Parsers MUST ignore all `$`-prefixed keys |
-| `^[a-zA-Z_][a-zA-Z0-9_]*$` | string | Variable mapping: env var name → secret identifier |
+| Any other key | string | Variable mapping: env var name → secret identifier |
+
+Variable names SHOULD match `^[a-zA-Z_][a-zA-Z0-9_]*$` (valid POSIX env var
+names). Parsers MUST NOT reject keys that don't match — this is a recommended
+convention, not a runtime constraint. Existing files with hyphens or dots in
+keys remain valid.
 
 At least one variable mapping is required for meaningful operation.
 
@@ -65,7 +70,7 @@ rejected to catch typos.
 
 | Field | Type | Constraint | Purpose |
 | ----- | ---- | ---------- | ------- |
-| `provider` | enum | `aws`, `azure`, `gcp`, `hashicorp`, `file` | Secret provider. Default: `aws` |
+| `provider` | enum | `aws`, `azure`, `gcp`, `hashicorp`, `file` | Secret provider. Default: `aws`. Note: `gcp` and `hashicorp` are planned — not yet implemented in CLI or SDKs |
 | `profile` | string | AWS-only | AWS CLI profile name |
 | `vaultUrl` | string (URI) | Azure/HashiCorp-only | Vault endpoint URL |
 | `projectId` | string | GCP-only | GCP project identifier |
@@ -83,8 +88,12 @@ rejected to catch typos.
 
 ### 4. One File, One Provider, One Environment
 
-A map file targets a single provider and a single environment. Multi-provider
-and multi-environment setups use separate files:
+A map file targets a single provider and a single environment. This is an
+**organizational convention**, not a runtime-enforced constraint. The
+`environment` metadata field is informational (ignored by runtime) and serves
+discoverability in projects with many map files.
+
+Multi-provider and multi-environment setups use separate files:
 
 ```txt
 param-map.prod.json      → $config.provider: "aws"
@@ -142,10 +151,15 @@ Envilder.load("param-map.json", EnvilderOptions.from_file(".env.test"))
 await Envilder.load('param-map.json', EnvilderOptions.fromFile('.env.test'));
 ```
 
+> **Implementation note (Node.js):** The current Node SDK uses the second
+> `load()` parameter for env-routing maps. The exact API shape for combining
+> file-provider options with env-routing will be resolved during implementation
+> to avoid overload ambiguity.
+
 `FromFile` is the primary testing mechanism — centralized source of truth in a
 single `.env.test` file.
 
-`WithDefaults(dict)` is an optional companion for per-test overrides:
+`WithOverride` is an optional companion for per-test overrides:
 
 ```csharp
 Envilder.Load("param-map.json", EnvilderOptions.FromFile(".env.test")
@@ -158,28 +172,43 @@ All keys starting with `$` are reserved for Envilder. Parsers MUST skip any
 `$`-prefixed key when building the variable mapping. This replaces the current
 exact-match on `$config` and future-proofs the format for new reserved keys.
 
-**Backward compatibility:** Existing map files (without `$schema` or `$meta`)
+**Backward compatibility:** Existing map files (without `$schema` or `$config`)
 work identically. The only behavioral change: SDKs stop making vault calls for
 `$schema` values that would previously leak through as variable mappings.
 
 ### 8. JSON Schema Publication
 
-The schema is published at `https://envilder.com/schema/map-file.v1.json` and
-versioned via URL. No `version` field inside the file. Files without `$schema`
-are assumed v1.
+The schema will be published at `https://envilder.com/schema/map-file.v1.json`
+and versioned via URL. No `version` field inside the file. Files without
+`$schema` are assumed v1.
 
-The schema file lives in the repository at `spec/map-file.v1.json`.
+The schema file will live in the repository at `spec/map-file.v1.json`.
+
+> **Implementation status:** Schema publication is pending. The URL and file
+> will be created in a follow-up PR.
 
 ### 9. Cross-Provider Validation Rules
 
-SDKs MUST validate and reject incompatible `$config` combinations:
+SDKs MUST reject any provider-specific `$config` field that does not belong to
+the active provider. Each field has exactly one valid provider:
+
+| Field | Valid provider(s) |
+| ----- | ----------------- |
+| `profile` | `aws` |
+| `vaultUrl` | `azure`, `hashicorp` |
+| `projectId` | `gcp` |
+| `namespace` | `hashicorp` |
+| `path` | `file` |
+
+**Examples of rejected combinations:**
 
 | Combination | Result |
 | ----------- | ------ |
-| `profile` + `provider: "azure"` | Error |
-| `vaultUrl` + `provider: "aws"` | Error |
-| `path` + `provider: "aws"` | Error |
-| `projectId` + `provider: "azure"` | Error |
+| `profile` + `provider: "azure"` | Error: `profile` is AWS-only |
+| `vaultUrl` + `provider: "aws"` | Error: `vaultUrl` is Azure/HashiCorp-only |
+| `path` + `provider: "aws"` | Error: `path` is file-only |
+| `projectId` + `provider: "file"` | Error: `projectId` is GCP-only |
+| `namespace` + `provider: "aws"` | Error: `namespace` is HashiCorp-only |
 
 ## Consequences
 

--- a/docs/architecture/adr/0008-map-file-schema.md
+++ b/docs/architecture/adr/0008-map-file-schema.md
@@ -1,0 +1,210 @@
+# ADR-0008: Map-File Schema Specification
+
+## Status
+
+Accepted
+
+## Context
+
+The map-file is Envilder's universal contract — a JSON file mapping environment
+variable names to cloud secret paths. Every component (CLI, GitHub Action, and
+all runtime SDKs) parses this format.
+
+Despite being the core of the product, the format has no formal specification:
+
+- No JSON Schema for IDE autocomplete or validation
+- No documented rules for reserved keys (`$config` is implicit, undocumented)
+- No defined set of `$config` fields — each SDK parses what it knows
+- No variable naming constraints — anything goes
+- Parsers filter `$config` by exact key match, not by reserved prefix — adding
+  new reserved keys (e.g., `$schema`) would leak into variable mappings
+
+Additionally, consumers need a testing story that doesn't require a real vault.
+The current SDKs offer no built-in mechanism to resolve secrets from a local
+file during development or CI.
+
+## Decision
+
+### 1. Map-File Format (v1)
+
+```json
+{
+  "$schema": "https://envilder.com/schema/map-file.v1.json",
+  "$config": {
+    "name": "payments-api",
+    "description": "Production secrets for payments microservice",
+    "owner": "platform-team",
+    "environment": "production",
+    "provider": "aws",
+    "profile": "prod-eu"
+  },
+  "DB_PASSWORD": "/payments/prod/db-password",
+  "API_KEY": "/payments/prod/api-key"
+}
+```
+
+### 2. Root-Level Structure
+
+The root object contains exactly two categories of keys:
+
+| Key pattern | Type | Purpose |
+| ----------- | ---- | ------- |
+| `$schema` | string (URI) | Optional. Standard JSON Schema reference for IDE autocomplete |
+| `$config` | object | Optional. Provider configuration and file metadata |
+| Any key starting with `$` | — | Reserved. Parsers MUST ignore all `$`-prefixed keys |
+| `^[a-zA-Z_][a-zA-Z0-9_]*$` | string | Variable mapping: env var name → secret identifier |
+
+At least one variable mapping is required for meaningful operation.
+
+### 3. `$config` Fields
+
+All fields are optional. `additionalProperties: false` — unknown fields are
+rejected to catch typos.
+
+**Provider configuration:**
+
+| Field | Type | Constraint | Purpose |
+| ----- | ---- | ---------- | ------- |
+| `provider` | enum | `aws`, `azure`, `gcp`, `hashicorp`, `file` | Secret provider. Default: `aws` |
+| `profile` | string | AWS-only | AWS CLI profile name |
+| `vaultUrl` | string (URI) | Azure/HashiCorp-only | Vault endpoint URL |
+| `projectId` | string | GCP-only | GCP project identifier |
+| `path` | string | File-only | Path to `.env` source file |
+| `namespace` | string | HashiCorp-only | Vault namespace |
+
+**Metadata (informational, ignored by runtime):**
+
+| Field | Type | Purpose |
+| ----- | ---- | ------- |
+| `name` | string | Short identifier (useful for logs, CLI output) |
+| `description` | string | What this file covers |
+| `owner` | string | Responsible team or person |
+| `environment` | string | Target environment (e.g., `production`, `staging`, `development`, `test`) |
+
+### 4. One File, One Provider, One Environment
+
+A map file targets a single provider and a single environment. Multi-provider
+and multi-environment setups use separate files:
+
+```
+param-map.prod.json      → $config.provider: "aws"
+param-map.staging.json   → $config.provider: "aws", different paths
+param-map.dev.json       → $config.provider: "file"
+```
+
+If a consumer needs secrets from two providers, they make two `load()` calls
+with two map files. This keeps the schema simple and avoids combinatorial
+complexity in all SDKs.
+
+### 5. Variable Mapping Semantics
+
+Values are opaque identifiers interpreted by the provider:
+
+| Provider | Value meaning | Example |
+| -------- | ------------- | ------- |
+| `aws` | SSM Parameter Store path | `/my-app/prod/db-password` |
+| `azure` | Key Vault secret name | `my-app-prod-db-password` |
+| `gcp` | Secret Manager secret name | `my-app-prod-db-password` |
+| `hashicorp` | Vault secret path | `secret/data/my-app/db-password` |
+| `file` | Key name in the `.env` source file | `DB_PASSWORD` |
+
+### 6. `file` Provider for Testing
+
+The `file` provider enables testing without cloud infrastructure. It reads an
+`.env` file and resolves mappings by key lookup.
+
+Consumers activate it via:
+
+**A) Map file (dedicated test config):**
+
+```json
+{
+  "$config": { "provider": "file", "path": ".env.test" },
+  "DB_PASSWORD": "DB_PASSWORD",
+  "API_KEY": "API_KEY"
+}
+```
+
+**B) SDK options override (no separate map file):**
+
+```csharp
+// .NET
+Envilder.Load("param-map.json", EnvilderOptions.FromFile(".env.test"));
+```
+
+```python
+# Python
+Envilder.load("param-map.json", EnvilderOptions.from_file(".env.test"))
+```
+
+```typescript
+// Node.js
+await Envilder.load('param-map.json', EnvilderOptions.fromFile('.env.test'));
+```
+
+`FromFile` is the primary testing mechanism — centralized source of truth in a
+single `.env.test` file.
+
+`WithDefaults(dict)` is an optional companion for per-test overrides:
+
+```csharp
+Envilder.Load("param-map.json", EnvilderOptions.FromFile(".env.test")
+    .WithOverride("DB_PASSWORD", "intentionally-wrong"));
+```
+
+### 7. Reserved Prefix Rule
+
+All keys starting with `$` are reserved for Envilder. Parsers MUST skip any
+`$`-prefixed key when building the variable mapping. This replaces the current
+exact-match on `$config` and future-proofs the format for new reserved keys.
+
+**Backward compatibility:** Existing map files (without `$schema` or `$meta`)
+work identically. The only behavioral change: SDKs stop making vault calls for
+`$schema` values that would previously leak through as variable mappings.
+
+### 8. JSON Schema Publication
+
+The schema is published at `https://envilder.com/schema/map-file.v1.json` and
+versioned via URL. No `version` field inside the file. Files without `$schema`
+are assumed v1.
+
+The schema file lives in the repository at `spec/map-file.v1.json`.
+
+### 9. Cross-Provider Validation Rules
+
+SDKs MUST validate and reject incompatible `$config` combinations:
+
+| Combination | Result |
+| ----------- | ------ |
+| `profile` + `provider: "azure"` | Error |
+| `vaultUrl` + `provider: "aws"` | Error |
+| `path` + `provider: "aws"` | Error |
+| `projectId` + `provider: "azure"` | Error |
+
+## Consequences
+
+### Positive
+
+- IDEs provide autocomplete and validation via `$schema`
+- Typos in `$config` fields are caught by strict schema validation
+- `file` provider eliminates the need for cloud infrastructure in consumer tests
+- Reserved `$` prefix future-proofs the format without breaking changes
+- Metadata fields (`name`, `owner`, `environment`) improve discoverability in
+  large projects with many map files
+
+### Negative
+
+- All parsers (4 stacks) need a one-line change from exact match to prefix
+  filter. Backward compatible but requires coordinated release.
+- `additionalProperties: false` on `$config` means new fields require a schema
+  update. Acceptable — new fields should be deliberate.
+- `file` provider adds a new adapter to each SDK. Minimal effort per SDK since
+  it implements the existing `ISecretProvider` interface.
+
+## When to Reconsider
+
+- If multi-provider per file becomes a common request (currently deemed rare)
+- If consumers need computed values or expressions in mappings (currently
+  string-only)
+- If `additionalProperties: false` blocks too many legitimate extensions
+  (loosen to `true` with a warning)


### PR DESCRIPTION
## Summary

Defines the formal JSON Schema v1 for the map-file format — the universal contract between CLI, GitHub Action, and all runtime SDKs.

## Key Decisions

- **Root structure**: `$schema` (IDE autocomplete) + `$config` (config + metadata) + variables
- **Reserved `$` prefix**: parsers MUST ignore all `$`-prefixed keys (replaces exact-match on `$config`)
- **`$config` strict fields**: provider, profile, vaultUrl, projectId, path, namespace + metadata (name, description, owner, environment)
- **`file` provider**: enables consumer testing without cloud infrastructure via `EnvilderOptions.FromFile(path)`
- **One file = one provider = one environment**
- **Variable name pattern**: `^[a-zA-Z_][a-zA-Z0-9_]*$`
- **`additionalProperties: false`** on `$config` to catch typos

## Follow-up Work

- [ ] Publish JSON Schema at `spec/map-file.v1.json`
- [ ] Update parsers (4 stacks) from exact `$config` match to `$` prefix filter
- [ ] Implement `file` provider in each SDK
- [ ] Implement `EnvilderOptions.FromFile` in each SDK
- [ ] Host schema at `https://envilder.com/schema/map-file.v1.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added schema specification documentation (v1) for map files, detailing required structure, configuration options, supported providers, parsing rules, and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->