### PR TITLE
docs(architecture): add ADR-0005 SDK integration tiers, ADR-0006 monorepo structure, ADR-0007 trunk-based development

### DIFF
--- a/.github/skills/common-architecture-decisions/SKILL.md
+++ b/.github/skills/common-architecture-decisions/SKILL.md
@@ -31,6 +31,7 @@ behind tooling choices and architectural patterns before proposing changes.
 | [ADR-0002](../../../docs/architecture/adr/0002-test-tooling-per-stack.md) | Test Tooling per Stack | All stacks | Vitest (TS), xUnit+NSubstitute+AwesomeAssertions (NET), pytest+unittest.mock (Py) |
 | [ADR-0003](../../../docs/architecture/adr/0003-sdk-architecture-pattern.md) | SDK Architecture Pattern | All SDKs | Three-layer (Domain→App→Infra), no DI framework, facade as primary API, internal factory |
 | [ADR-0004](../../../docs/architecture/adr/0004-code-quality-tooling.md) | Code Quality and Formatting | All stacks | Biome (TS), dotnet format (.NET), black+isort (Py); Secretlint for credentials |
+| [ADR-0005](../../../docs/architecture/adr/0005-sdk-integration-tiers.md) | SDK Integration Tiers | All SDKs | Three tiers (Facade, Builder, Framework); Tier 3 separate package; .NET exception; community-driven |
 
 ## Quick Reference: Test Doubles per Stack
 

--- a/.github/skills/common-architecture-decisions/SKILL.md
+++ b/.github/skills/common-architecture-decisions/SKILL.md
@@ -32,7 +32,7 @@ behind tooling choices and architectural patterns before proposing changes.
 | [ADR-0003](../../../docs/architecture/adr/0003-sdk-architecture-pattern.md) | SDK Architecture Pattern | All SDKs | Three-layer (Domain→App→Infra), no DI framework, facade as primary API, internal factory |
 | [ADR-0004](../../../docs/architecture/adr/0004-code-quality-tooling.md) | Code Quality and Formatting | All stacks | Biome (TS), dotnet format (.NET), black+isort (Py); Secretlint for credentials |
 | [ADR-0005](../../../docs/architecture/adr/0005-sdk-integration-tiers.md) | SDK Integration Tiers | All SDKs | Three tiers (Facade, Builder, Framework); Tier 3 separate package; .NET exception; community-driven |
-| [ADR-0006](../../../docs/architecture/adr/0006-monorepo-structure.md) | Monorepo Structure | All components | Single repo, independent releases per component via tags, no orchestrator |
+| [ADR-0006](../../../docs/architecture/adr/0006-monorepo-structure.md) | Monorepo Structure | All components | Single repo, independent releases per component via version-bump detection, no orchestrator |
 | [ADR-0007](../../../docs/architecture/adr/0007-trunk-based-development.md) | Trunk-Based Development | All components | Single main branch, short-lived feature branches, squash merge, feature flags for incomplete work |
 
 ## Quick Reference: Test Doubles per Stack

--- a/.github/skills/common-architecture-decisions/SKILL.md
+++ b/.github/skills/common-architecture-decisions/SKILL.md
@@ -32,6 +32,8 @@ behind tooling choices and architectural patterns before proposing changes.
 | [ADR-0003](../../../docs/architecture/adr/0003-sdk-architecture-pattern.md) | SDK Architecture Pattern | All SDKs | Three-layer (Domain→App→Infra), no DI framework, facade as primary API, internal factory |
 | [ADR-0004](../../../docs/architecture/adr/0004-code-quality-tooling.md) | Code Quality and Formatting | All stacks | Biome (TS), dotnet format (.NET), black+isort (Py); Secretlint for credentials |
 | [ADR-0005](../../../docs/architecture/adr/0005-sdk-integration-tiers.md) | SDK Integration Tiers | All SDKs | Three tiers (Facade, Builder, Framework); Tier 3 separate package; .NET exception; community-driven |
+| [ADR-0006](../../../docs/architecture/adr/0006-monorepo-structure.md) | Monorepo Structure | All components | Single repo, independent releases per component via tags, no orchestrator |
+| [ADR-0007](../../../docs/architecture/adr/0007-trunk-based-development.md) | Trunk-Based Development | All components | Single main branch, short-lived feature branches, squash merge, feature flags for incomplete work |
 
 ## Quick Reference: Test Doubles per Stack
 

--- a/.github/skills/common-git/SKILL.md
+++ b/.github/skills/common-git/SKILL.md
@@ -116,16 +116,15 @@ Use **Squash and Merge** to keep main branch clean:
 ### Trunk-Based Development
 
 - **main** - Production-ready code
-- **feature/** - Feature branches (short-lived)
-- **fix/** - Bug fix branches (short-lived)
+- **{usergithub}/{type}/{name}** - All work branches (short-lived)
 
 ### Branch Naming
 
 ```txt
-feature/add-azure-provider
-fix/windows-path-resolution
-refactor/extract-provider-factory
-docs/add-nodejs-sdk-references
+macalbert/feat/add-azure-provider
+macalbert/fix/windows-path-resolution
+macalbert/refactor/extract-provider-factory
+macalbert/docs/add-nodejs-sdk-references
 ```
 
 ### Workflow

--- a/.github/skills/common-git/reference.md
+++ b/.github/skills/common-git/reference.md
@@ -25,10 +25,10 @@ Subject: imperative mood, ≤50 chars, no period, capitalized.
 ## Branch Naming
 
 ```txt
-feature/add-group-coupons
-fix/stripe-webhook-validation
-refactor/split-repositories
-docs/update-architecture-adr
+macalbert/feat/add-group-coupons
+macalbert/fix/stripe-webhook-validation
+macalbert/refactor/split-repositories
+macalbert/docs/update-architecture-adr
 ```
 
 ## PR Workflow

--- a/.github/skills/sdk-implementation-guide/SKILL.md
+++ b/.github/skills/sdk-implementation-guide/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: sdk-implementation-guide
+description: >-
+  Operational guide for implementing a new Envilder runtime SDK. Covers folder
+  structure, API surface (Tier 1 + Tier 2), provider contract, naming
+  conventions, sync/async model, internal vs public separation, vanity imports,
+  and testing skeleton. Use when creating Go, Java, PHP, Rust, or any future SDK.
+---
+
+# SDK Implementation Guide
+
+Step-by-step guide for building a new Envilder runtime SDK. Complements
+ADR-0003 (architecture pattern) and ADR-0005 (integration tiers). For website
+wiring and publishing, see the `sdk-release-checklist` skill.
+
+## When to Use
+
+- Implementing a new runtime SDK (Go, Java, PHP, Rust, etc.)
+- Reviewing an SDK PR for pattern compliance
+- Onboarding a contributor to SDK development
+
+## Prerequisites
+
+Before starting, read:
+
+- [ADR-0003: SDK Architecture Pattern](../../../docs/architecture/adr/0003-sdk-architecture-pattern.md)
+- [ADR-0005: SDK Integration Tiers](../../../docs/architecture/adr/0005-sdk-integration-tiers.md)
+
+## 1. Folder Structure
+
+```
+src/sdks/{runtime}/
+├── domain/
+│   ├── ISecretProvider          ← Port interface/protocol
+│   ├── MapFileConfig            ← Config parsed from $config
+│   ├── EnvilderOptions          ← Runtime overrides
+│   ├── ParsedMapFile            ← Config + variable mappings
+│   └── SecretProviderType       ← Enum (aws, azure)
+├── application/
+│   ├── Envilder                 ← Public facade (Tier 1 + Tier 2)
+│   ├── EnvilderClient           ← Core resolver
+│   ├── MapFileParser            ← JSON parsing logic
+│   └── SecretValidation         ← Opt-in validate function
+├── infrastructure/
+│   ├── SecretProviderFactory    ← Internal, not exported
+│   ├── aws/
+│   │   └── AwsSsmSecretProvider
+│   └── azure/
+│       └── AzureKeyVaultSecretProvider
+└── integrations/                ← Tier 3 (future, community-driven)
+    └── {framework}/
+```
+
+Tests mirror the structure under `tests/sdks/{runtime}/`.
+
+## 2. Mandatory API Surface
+
+### Tier 1 — Static Facade (one-liner)
+
+```
+Envilder.load("map.json")              → injects into process env
+Envilder.resolveFile("map.json")       → returns resolved key-value pairs
+```
+
+### Tier 2 — Fluent Builder
+
+```
+Envilder.fromMapFile("map.json")
+  .withProvider("azure")
+  .withVaultUrl("https://vault.azure.net")
+  .withProfile("my-profile")           // AWS only
+  .inject()                            // injects into env
+  // OR
+  .resolve()                           // returns key-value pairs
+```
+
+### Environment Routing (both tiers)
+
+```
+Envilder.load("production", {
+  "production": "prod-map.json",
+  "staging": "stg-map.json"
+})
+```
+
+## 3. Provider Contract
+
+| Aspect | Decision |
+| ------ | -------- |
+| Missing secrets | Return null/None/nil — never throw |
+| Validation | Opt-in `validateSecrets()` post-resolution |
+| Cross-provider validation | profile + Azure → error; vaultUrl + AWS → error |
+| Options override config | Runtime `EnvilderOptions` > `$config` from map file |
+| Pull-only | SDKs do not support push mode |
+
+### Sync vs Async per Runtime
+
+| Runtime | Model | Rationale |
+| ------- | ----- | --------- |
+| .NET | Both (sync + async methods) | `IConfigurationBuilder` needs sync |
+| Python | Sync only | boto3 is natively synchronous |
+| Node.js | Async only | AWS SDK v3 is async, natural fit |
+| Go | Sync (with goroutines for batch) | Idiomatic Go |
+| Java/Kotlin | Both (sync + async/CompletableFuture) | Spring uses both patterns |
+| PHP | Sync only | PHP is single-threaded by default |
+| Rust | Async (tokio) | AWS SDK for Rust is async |
+
+### Batch vs Individual
+
+| Runtime | Strategy | Rationale |
+| ------- | -------- | --------- |
+| Node.js | Batch (`GetParameters`, max 10) | Avoids waterfall awaits |
+| .NET | Individual (`GetParameter`) | Simpler error handling per secret |
+| Python | Individual (`get_parameter`) | Matches boto3 API |
+| Go | Batch preferred | Reduce round trips |
+| Java | Batch preferred | AWS SDK supports batch |
+| PHP | Individual | Simpler for first iteration |
+| Rust | Batch preferred | Async batch is natural |
+
+## 4. Internal vs Public Separation
+
+The `SecretProviderFactory` is always **internal** (not part of public API):
+
+| Runtime | Mechanism |
+| ------- | --------- |
+| .NET | `internal` keyword + `InternalsVisibleTo` for tests |
+| Python | `_` prefix (`_SecretProviderFactory`) + `__all__` whitelist |
+| Node.js | Not re-exported from barrel `index.ts` |
+| Go | Unexported (`secretProviderFactory`, lowercase) |
+| Java/Kotlin | Package-private or `internal` (Kotlin) |
+| PHP | Prefixed `_` or `@internal` docblock |
+| Rust | `pub(crate)` visibility |
+
+## 5. Naming Conventions
+
+### Package/Module Names
+
+| Runtime | Package name | Import |
+| ------- | ------------ | ------ |
+| .NET | `Envilder` (NuGet) | `using Envilder;` |
+| Python | `envilder` (PyPI) | `from envilder import Envilder` |
+| Node.js | `@envilder/sdk` (npm) | `import { Envilder } from '@envilder/sdk'` |
+| Go | `envilder.com/go` (vanity) | `import "envilder.com/go"` |
+| Java/Kotlin | `com.envilder:envilder` (Maven) | `import com.envilder.Envilder;` |
+| PHP | `envilder/envilder` (Packagist) | `use Envilder\Envilder;` |
+| Rust | `envilder` (crates.io) | `use envilder::Envilder;` |
+
+### Class/Struct Naming
+
+- Facade class is always `Envilder` (consistent cross-SDK brand)
+- Client class is always `EnvilderClient`
+- Provider interface: `ISecretProvider` (or language equivalent: Protocol, trait, interface)
+
+## 6. Vanity Imports (Go)
+
+Go module path is `envilder.com/go`. This requires a vanity import HTML at
+`https://envilder.com/go?go-get=1`:
+
+```html
+<meta name="go-import" content="envilder.com/go git https://github.com/macalbert/envilder">
+<meta name="go-source" content="envilder.com/go https://github.com/macalbert/envilder https://github.com/macalbert/envilder/tree/main/src/sdks/go{/dir} https://github.com/macalbert/envilder/tree/main/src/sdks/go{/dir}/{file}#L{line}">
+```
+
+Serve from the Envilder website (`src/website/public/go/index.html`).
+
+## 7. Testing Skeleton
+
+Every SDK must have:
+
+- [ ] Unit tests for `MapFileParser`
+- [ ] Unit tests for `EnvilderClient` (mock `ISecretProvider`)
+- [ ] Unit tests for `Envilder` facade (mock client/provider)
+- [ ] Unit tests for `SecretValidation`
+- [ ] Unit tests for cross-provider validation
+- [ ] Acceptance tests with LocalStack (AWS SSM)
+- [ ] Acceptance tests with Lowkey Vault (Azure Key Vault)
+
+Follow `sdk-acceptance-testing` skill for container wrapper patterns.
+
+## 8. Implementation Order (per SDK)
+
+1. Domain types (`MapFileConfig`, `EnvilderOptions`, `SecretProviderType`, `ISecretProvider`)
+2. `MapFileParser` + tests
+3. `EnvilderClient` + tests
+4. `AwsSsmSecretProvider` + acceptance tests
+5. `AzureKeyVaultSecretProvider` + acceptance tests
+6. `Envilder` facade (Tier 1 + Tier 2) + tests
+7. `SecretValidation` + tests
+8. Cross-provider validation + tests
+9. README, changelog, website wiring (→ `sdk-release-checklist` skill)
+
+## 9. Checklist Before Submitting PR
+
+- [ ] All unit tests pass
+- [ ] All acceptance tests pass (Docker required)
+- [ ] `SecretProviderFactory` is not publicly exported
+- [ ] Tier 1 (`load`) and Tier 2 (`fromMapFile().inject()`) work end-to-end
+- [ ] Missing secrets silently omitted (no exceptions from provider)
+- [ ] `validateSecrets()` throws on empty/missing values
+- [ ] Cross-provider errors: profile+Azure→error, vaultUrl+AWS→error
+- [ ] Options override `$config` values
+- [ ] Environment routing works
+- [ ] Follows language-idiomatic conventions (naming, async model, visibility)

--- a/.github/skills/sdk-implementation-guide/SKILL.md
+++ b/.github/skills/sdk-implementation-guide/SKILL.md
@@ -28,7 +28,7 @@ Before starting, read:
 
 ## 1. Folder Structure
 
-```
+```txt
 src/sdks/{runtime}/
 ├── domain/
 │   ├── ISecretProvider          ← Port interface/protocol
@@ -87,7 +87,7 @@ Envilder.load("production", {
 
 | Aspect | Decision |
 | ------ | -------- |
-| Missing secrets | Return null/None/nil — never throw |
+| Missing secrets | Return null/None/nil (Option<T> in Rust) — never throw |
 | Validation | Opt-in `validateSecrets()` post-resolution |
 | Cross-provider validation | profile + Azure → error; vaultUrl + AWS → error |
 | Options override config | Runtime `EnvilderOptions` > `$config` from map file |
@@ -100,7 +100,7 @@ Envilder.load("production", {
 | .NET | Both (sync + async methods) | `IConfigurationBuilder` needs sync |
 | Python | Sync only | boto3 is natively synchronous |
 | Node.js | Async only | AWS SDK v3 is async, natural fit |
-| Go | Sync (with goroutines for batch) | Idiomatic Go |
+| Go | Sync (with context.Context and goroutines for batch) | Idiomatic Go |
 | Java/Kotlin | Both (sync + async/CompletableFuture) | Spring uses both patterns |
 | PHP | Sync only | PHP is single-threaded by default |
 | Rust | Async (tokio) | AWS SDK for Rust is async |
@@ -128,7 +128,7 @@ The `SecretProviderFactory` is always **internal** (not part of public API):
 | Node.js | Not re-exported from barrel `index.ts` |
 | Go | Unexported (`secretProviderFactory`, lowercase) |
 | Java/Kotlin | Package-private or `internal` (Kotlin) |
-| PHP | Prefixed `_` or `@internal` docblock |
+| PHP | Prefixed `_` or `#[Internal]` attribute / `@internal` docblock |
 | Rust | `pub(crate)` visibility |
 
 ## 5. Naming Conventions

--- a/.github/skills/sdk-implementation-guide/SKILL.md
+++ b/.github/skills/sdk-implementation-guide/SKILL.md
@@ -57,14 +57,14 @@ Tests mirror the structure under `tests/sdks/{runtime}/`.
 
 ### Tier 1 — Static Facade (one-liner)
 
-```
+```txt
 Envilder.load("map.json")              → injects into process env
 Envilder.resolveFile("map.json")       → returns resolved key-value pairs
 ```
 
 ### Tier 2 — Fluent Builder
 
-```
+```txt
 Envilder.fromMapFile("map.json")
   .withProvider("azure")
   .withVaultUrl("https://vault.azure.net")
@@ -76,7 +76,7 @@ Envilder.fromMapFile("map.json")
 
 ### Environment Routing (both tiers)
 
-```
+```txt
 Envilder.load("production", {
   "production": "prod-map.json",
   "staging": "stg-map.json"

--- a/.github/skills/sdk-implementation-guide/SKILL.md
+++ b/.github/skills/sdk-implementation-guide/SKILL.md
@@ -53,6 +53,10 @@ src/sdks/{runtime}/
 
 Tests mirror the structure under `tests/sdks/{runtime}/`.
 
+> **Note:** This is the logical structure. Each runtime adapts to its own
+> conventions (e.g., Node.js uses `src/` subfolder, Python uses package name
+> as root directory).
+
 ## 2. Mandatory API Surface
 
 ### Tier 1 — Static Facade (one-liner)
@@ -87,7 +91,7 @@ Envilder.load("production", {
 
 | Aspect | Decision |
 | ------ | -------- |
-| Missing secrets | Return null/None/nil (Option<T> in Rust) — never throw |
+| Missing secrets | Return null/None/nil (Option<T> in Rust) or omit from result collection — never throw |
 | Validation | Opt-in `validateSecrets()` post-resolution |
 | Cross-provider validation | profile + Azure → error; vaultUrl + AWS → error |
 | Options override config | Runtime `EnvilderOptions` > `$config` from map file |

--- a/docs/architecture/adr/0005-sdk-integration-tiers.md
+++ b/docs/architecture/adr/0005-sdk-integration-tiers.md
@@ -12,7 +12,7 @@ with dependency injection:
 
 | Runtime | DI landscape |
 | ------- | ------------ |
-| .NET | `IServiceCollection` is the de facto universal standard (~99% adoption) |
+| .NET | `IServiceCollection` is the de facto universal standard |
 | Java/Kotlin | Fragmented: Spring, Guice, Dagger, CDI |
 | Python | No standard: Django has its own, FastAPI uses `Depends` |
 | Node.js | Fragmented: NestJS has its own, Express has none |

--- a/docs/architecture/adr/0005-sdk-integration-tiers.md
+++ b/docs/architecture/adr/0005-sdk-integration-tiers.md
@@ -1,0 +1,120 @@
+# ADR-0005: SDK Integration Tiers
+
+## Status
+
+Accepted
+
+## Context
+
+Envilder provides runtime SDKs across multiple ecosystems (.NET, Python,
+Node.js, Go, Java, PHP, Rust). Each ecosystem has a different relationship
+with dependency injection:
+
+| Runtime | DI landscape |
+| ------- | ------------ |
+| .NET | `IServiceCollection` is the de facto universal standard (~99% adoption) |
+| Java/Kotlin | Fragmented: Spring, Guice, Dagger, CDI |
+| Python | No standard: Django has its own, FastAPI uses `Depends` |
+| Node.js | Fragmented: NestJS has its own, Express has none |
+| Go | Convention is manual constructor injection (no DI container) |
+| PHP | Fragmented: Symfony DI, Laravel Service Container |
+| Rust | No runtime DI (not applicable) |
+
+ADR-0003 defines the public API surface (Simple, Fluent, Advanced levels) and
+the three-layer architecture. This ADR extends that by addressing how SDKs
+integrate with host application frameworks — specifically around DI containers
+and configuration pipelines.
+
+## Decision
+
+### 1. Three Integration Tiers
+
+Each SDK exposes up to three tiers of integration. Only Tier 1 and Tier 2 are
+mandatory for every SDK:
+
+| Tier | Name | Description | Mandatory |
+| ---- | ---- | ----------- | --------- |
+| **Tier 1** | Static Facade | One-liner, zero config. Secrets injected into process environment. | Yes |
+| **Tier 2** | Fluent Builder | Configurable step-by-step API. Provider, vault URL, profile, etc. Same package as Tier 1. | Yes |
+| **Tier 3** | Framework Integration | Native integration with a specific framework's DI/config system. Separate package. | No |
+
+### 2. Tier 3 Rules
+
+- **Core SDK never depends on a framework DI container.** The dependency
+  direction is: `envilder-{framework}` → `envilder` (core), never the reverse.
+- Tier 3 packages follow the naming pattern: `envilder-{framework}`
+  (e.g., `com.envilder:envilder-spring`, `envilder/laravel`, `@envilder/nestjs`).
+- Tier 3 lives in `src/sdks/{runtime}/integrations/{framework}/` within the
+  monorepo.
+
+### 3. .NET Exception
+
+.NET is the only runtime where Tier 3 extensions (`IServiceCollection.AddEnvilder()`,
+`IConfigurationBuilder.AddEnvilder()`) live inside the core package. Rationale:
+`IServiceCollection` is the universal DI standard in .NET — separating it would
+be over-engineering with no practical benefit.
+
+### 4. Tier 3 Is Community-Driven
+
+Tier 3 will not be implemented for any new runtime until the community
+explicitly requests it via GitHub issues or discussions. The core SDK (Tier 1 +
+Tier 2) is sufficient for all use cases — Tier 3 is a convenience layer only.
+
+### 5. Current State
+
+| Runtime | Tier 1 | Tier 2 | Tier 3 |
+| ------- | ------ | ------ | ------ |
+| .NET | ✅ | ✅ | ✅ (in core, exception) |
+| Python | ✅ | ✅ | — |
+| Node.js | ✅ | ✅ | — |
+| Go | Planned | Planned | — |
+| Java/Kotlin | Planned | Planned | — |
+| PHP | Planned | Planned | — |
+| Rust | Planned | Planned | — |
+
+## Alternatives Considered
+
+### A. Single package with optional DI for all runtimes
+
+Include framework integrations inside the core SDK package, guarded behind
+optional dependencies or feature flags.
+
+**Rejected:** Forces transitive dependencies (Spring, Laravel, etc.) on all
+consumers regardless of whether they use the framework integration.
+
+### B. Never offer Tier 3 (facade-only for everyone)
+
+Only provide Tier 1 and Tier 2 across all ecosystems, including .NET.
+
+**Rejected:** Loses adoption in ecosystems where native DI integration is the
+expected standard (ASP.NET). The .NET SDK without `AddEnvilder()` would feel
+incomplete to its target audience.
+
+### C. Tier 3 mandatory for all SDKs from day one
+
+Ship every SDK with at least one framework integration (Spring for Java,
+Laravel for PHP, etc.).
+
+**Rejected:** Disproportionate effort and maintenance burden without proven
+demand. Violates YAGNI.
+
+## Consequences
+
+### Positive
+
+- SDKs remain lightweight — no framework lock-in forced on consumers
+- Clear separation of concerns: core secret loading vs framework wiring
+- Community-driven prioritization avoids wasted effort
+- .NET exception is pragmatic and matches ecosystem expectations
+
+### Negative
+
+- .NET is inconsistent with other SDKs (Tier 3 in core vs separate package)
+- Future Tier 3 packages add maintenance surface area per framework
+
+## When to Reconsider
+
+- When the community explicitly requests framework integration for a specific
+  runtime (tracked via GitHub issues/discussions)
+- When an ecosystem consolidates around a single DI standard (as .NET did)
+  making the "separate package" overhead unjustified

--- a/docs/architecture/adr/0006-monorepo-structure.md
+++ b/docs/architecture/adr/0006-monorepo-structure.md
@@ -31,17 +31,18 @@ Every component of the Envilder project lives in one Git repository:
 | SDK Node.js | `src/sdks/nodejs/` | pnpm workspace |
 | SDK Go | `src/sdks/go/` | go modules |
 | SDK Java/Kotlin | `src/sdks/java/` | Maven/Gradle |
-| SDK PHP | `src/sdks/php/` | Composer |
-| SDK Rust | `src/sdks/rust/` | Cargo |
+| SDK PHP (planned) | `src/sdks/php/` | Composer |
+| SDK Rust (planned) | `src/sdks/rust/` | Cargo |
 
 ### 2. Independent Releases per Component
 
-Each component has its own:
+Each shipped component (CLI, GHA, SDKs) has its own:
 
 - **Version source file** (package.json, .csproj, pyproject.toml, etc.)
 - **Changelog** (`docs/changelogs/{component}.md`)
 - **Git tag** following `{component}/v{semver}` (e.g., `sdk-dotnet/v1.2.0`)
-- **CI release workflow** triggered by its specific tag pattern
+- **CI release workflow** triggered by version-bump detection on push to `main`
+  (the workflow publishes, then creates the component tag post-publish)
 
 Components are never forced to release together. A change to the Python SDK
 does not require a new CLI release.

--- a/docs/architecture/adr/0006-monorepo-structure.md
+++ b/docs/architecture/adr/0006-monorepo-structure.md
@@ -1,0 +1,130 @@
+# ADR-0006: Monorepo Structure
+
+## Status
+
+Accepted
+
+## Context
+
+Envilder is a multi-component product: a TypeScript CLI, a GitHub Action,
+runtime SDKs in multiple languages (.NET, Python, Node.js, Go, Java, PHP,
+Rust), a documentation website, and infrastructure-as-code. These components
+share the map-file format as a universal contract and are released independently.
+
+A decision is needed on whether all components live in a single repository or
+are split across multiple repositories.
+
+## Decision
+
+### 1. All Components in a Single Repository
+
+Every component of the Envilder project lives in one Git repository:
+
+| Component | Path | Build System |
+| --------- | ---- | ------------ |
+| CLI (TypeScript) | `src/envilder/` | pnpm (root) |
+| GitHub Action | `github-action/` | ncc bundle |
+| Website (Astro) | `src/website/` | pnpm workspace |
+| IaC (CDK) | `src/iac/` | pnpm workspace |
+| SDK .NET | `src/sdks/dotnet/` | dotnet |
+| SDK Python | `src/sdks/python/` | uv |
+| SDK Node.js | `src/sdks/nodejs/` | pnpm workspace |
+| SDK Go | `src/sdks/go/` | go modules |
+| SDK Java/Kotlin | `src/sdks/java/` | Maven/Gradle |
+| SDK PHP | `src/sdks/php/` | Composer |
+| SDK Rust | `src/sdks/rust/` | Cargo |
+
+### 2. Independent Releases per Component
+
+Each component has its own:
+
+- **Version source file** (package.json, .csproj, pyproject.toml, etc.)
+- **Changelog** (`docs/changelogs/{component}.md`)
+- **Git tag** following `{component}/v{semver}` (e.g., `sdk-dotnet/v1.2.0`)
+- **CI release workflow** triggered by its specific tag pattern
+
+Components are never forced to release together. A change to the Python SDK
+does not require a new CLI release.
+
+### 3. No Monorepo Orchestrator
+
+Each SDK uses its native build system directly (dotnet, uv, cargo, go, etc.).
+There is no Nx, Turborepo, Bazel, or other orchestrator layer. `pnpm
+workspaces` is used only for TypeScript components that benefit from it.
+
+## Rationale
+
+| Reason | Detail |
+| ------ | ------ |
+| Atomic cross-component changes | A single PR can touch CLI + SDK + docs + website together |
+| Conformance sharing | Map-file spec, test fixtures, and examples are shared without submodules |
+| Unified CI | One pipeline sees everything — a CLI change can trigger SDK tests |
+| Single source of truth | One ROADMAP, one changelog index, one architectural vision |
+| Contributor simplicity | One `git clone`, one repo to understand the full project |
+
+## Alternatives Considered
+
+### Multi-repo (one repo per SDK)
+
+Each SDK lives in its own GitHub repository with its own CI, issues, and
+releases.
+
+**Rejected:** Fragments the product vision. Cross-component changes require
+coordinated PRs across repos. Shared fixtures need git submodules or duplicated
+files. Multiplies CI configuration. Complicates onboarding — contributors need
+to clone N repos to understand the product.
+
+### Monorepo with heavy tooling (Nx, Turborepo, Bazel)
+
+Add a build orchestrator to manage cross-component dependencies, caching, and
+task scheduling.
+
+**Rejected:** Over-engineering for the current project size. Each SDK has its
+own native build system (dotnet, uv, cargo, go) that works independently.
+Adding an orchestrator creates a learning curve for contributors and adds a
+maintenance burden without proportional benefit.
+
+### Git submodules for SDKs
+
+Keep SDKs in separate repos but reference them as submodules in the main repo.
+
+**Rejected:** Submodules add operational complexity (sync issues, nested
+clones, detached HEAD confusion). The DX for contributors is significantly
+worse. Updates require multi-step workflows instead of simple commits.
+
+## Consequences
+
+### Positive
+
+- One clone to get everything — fast onboarding
+- Shared CI infrastructure — one set of workflows, reusable across components
+- Atomic PRs across components — no coordination overhead
+- Single point of documentation and architectural decisions
+- Encourages consistency — conventions are visible and enforceable repo-wide
+
+### Negative
+
+- Repository size grows over time (mitigated by sparse checkout if needed)
+- CI must be selective — running all tests on every PR is wasteful (solved with
+  path-based triggers)
+- Go module path requires vanity import (envilder.com/go) since the repo path
+  would be too long
+- Contributors who only care about one SDK still clone the full repo
+
+## When to Reconsider
+
+All known alternatives (multi-repo, submodules, heavy orchestrators) are
+objectively worse for this project's size, team, and release model. Splitting
+the monorepo would be a step backwards in developer experience and operational
+simplicity.
+
+The only valid reason to reconsider would be the emergence of a repository
+strategy that is objectively superior for multi-component projects with
+independent releases — which does not exist today.
+
+Practical scenarios that might force adaptation (not abandonment):
+
+- Git performance degradation due to size — mitigate with sparse checkout
+  before considering a split
+- CI bottlenecks from unrelated components — solve with path-based triggers,
+  not repository splitting

--- a/docs/architecture/adr/0007-trunk-based-development.md
+++ b/docs/architecture/adr/0007-trunk-based-development.md
@@ -1,0 +1,113 @@
+# ADR-0007: Trunk-Based Development
+
+## Status
+
+Accepted
+
+## Context
+
+Envilder is a multi-component monorepo (CLI, GitHub Action, SDKs, website, IaC)
+with independent release cycles per component. The team needs a branching
+strategy that supports continuous delivery, fast feedback, and low ceremony
+while keeping `main` always deployable.
+
+## Decision
+
+### 1. Single Long-Lived Branch
+
+`main` is the only long-lived branch. It is always in a deployable state.
+There are no `develop`, `release/*`, or `hotfix/*` branches.
+
+### 2. Short-Lived Feature Branches
+
+All work happens in feature branches that merge to `main` via pull request.
+
+| Rule | Detail |
+| ---- | ------ |
+| Naming | `{usergithub}/{type}/{name}` (e.g., `macalbert/feat/go-sdk`) |
+| Lifetime | < 2-3 days (shorter is better) |
+| Merge strategy | Squash merge by default (clean linear history) |
+| Direct push to main | Never — always via PR |
+
+### 3. Quality Gates Before Merge
+
+CI must pass before a PR can be merged:
+
+- All tests (unit + acceptance where applicable)
+- Lint + format check
+- Commitlint validation
+
+### 4. Releases from Main via Tags
+
+Releases are triggered by creating a Git tag on `main` following the pattern
+`{component}/v{semver}` (e.g., `sdk-dotnet/v1.2.0`, `cli/v3.1.0`). No release
+branches needed.
+
+### 5. Feature Flags for Incomplete Features
+
+When a feature requires multiple PRs to complete, use feature flags to keep
+incomplete code behind a toggle. This allows merging to `main` without exposing
+unfinished functionality to users. Feature flags are removed once the feature
+is complete.
+
+### 6. Relationship with Continuous Delivery
+
+Trunk-Based Development is inseparable from Continuous Delivery. `main` being
+always deployable means any commit can be released at any time. This is a
+fundamental property of the workflow, not a side effect.
+
+## Alternatives Considered
+
+### Git Flow (develop + release + hotfix branches)
+
+Over-engineering for a project without multiple major versions in production
+simultaneously. Adds ceremony (merge develop → release → main → hotfix →
+develop) without value.
+
+**Rejected:** Complexity disproportionate to project needs.
+
+### GitHub Flow with long-lived feature branches
+
+Allow feature branches to live for weeks or months.
+
+**Rejected:** Long-lived branches generate merge conflicts, delay integration
+feedback, and break the continuous integration principle. The longer a branch
+lives, the riskier the merge.
+
+### Release branches per component
+
+Maintain a `release/sdk-dotnet-1.x` branch for each component's release cycle.
+
+**Rejected:** Tags per component (see monorepo ADR) achieve the same goal
+without the branch management overhead. Release branches add complexity when
+`main` is always deployable.
+
+## Consequences
+
+### Positive
+
+- Fast feedback loop — changes integrate into main within hours, not days
+- No merge hell — short branches rarely conflict
+- Always deployable — any commit on main can be released
+- Simple mental model — one branch, one truth
+- Clean history — squash merge keeps the log readable
+
+### Negative
+
+- Requires discipline — incomplete features must use flags, not long branches
+- CI must be fast — slow pipelines block the entire workflow
+- Not suitable for maintaining multiple major versions simultaneously
+
+## When to Reconsider
+
+Reconsidering TBD is effectively a step backwards from Continuous Delivery.
+The only valid reason would be the emergence of a branching strategy that is
+objectively superior to TBD for continuous delivery — which is unlikely given
+TBD+CD is the current industry gold standard.
+
+Practical scenarios that might force adaptation (not abandonment):
+
+- Maintaining multiple major versions simultaneously (v1.x + v2.x) — would
+  require long-lived support branches alongside TBD on main
+- Team scaling issues where merge queues or stricter branch protection become
+  necessary — these are additive (complement TBD, not replace it)

--- a/docs/architecture/adr/0007-trunk-based-development.md
+++ b/docs/architecture/adr/0007-trunk-based-development.md
@@ -35,11 +35,12 @@ CI must pass before a PR can be merged:
 
 - All tests (unit + acceptance where applicable)
 - Lint + format check
-- Commitlint validation
+- Commitlint validation (enforced locally via lefthook `commit-msg` hook)
 
-### 4. Releases from Main via Tags
+### 4. Releases from Main via Version Bumps
 
-Releases are triggered by creating a Git tag on `main` following the pattern
+Releases are triggered by version-bump detection on push to `main`. The CI
+workflow publishes the artifact and then creates a Git tag following the pattern
 `{component}/v{semver}` (e.g., `sdk-dotnet/v1.2.0`, `cli/v3.1.0`). No release
 branches needed.
 


### PR DESCRIPTION
## Summary

Adds three new Architecture Decision Records (ADR-0005, ADR-0006, ADR-0007) and a new SDK implementation guide skill. These ADRs formalize decisions around SDK integration tiers, monorepo structure, and trunk-based development workflow.

## Changes

- **ADR-0005** (docs/architecture/adr/0005-sdk-integration-tiers.md): Defines three integration tiers for SDKs (Facade, Builder, Framework), with Tier 3 as a separate package and .NET as the exception due to universal IServiceCollection adoption
- **ADR-0006** (docs/architecture/adr/0006-monorepo-structure.md): Documents the single-repo, independent-release-per-component strategy using tags, with no orchestrator
- **ADR-0007** (docs/architecture/adr/0007-trunk-based-development.md): Formalizes single main branch, short-lived feature branches, squash merge, and feature flags for incomplete work
- **SDK Implementation Guide** (.github/skills/sdk-implementation-guide/SKILL.md): New skill for guiding SDK development across runtimes
- **ADR Index Update** (.github/skills/common-architecture-decisions/SKILL.md): Adds ADR-0005, 0006, 0007 entries to the architecture decisions index

## Testing

- [ ] pnpm test passes
- [ ] pnpm lint passes
- [ ] Documentation-only changes — no runtime behavior affected

## Related

N/A
