### PR TITLE
feat(spec): add map-file JSON Schema v1

### DIFF
--- a/spec/map-file.v1.json
+++ b/spec/map-file.v1.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envilder.com/schema/map-file.v1.json",
+  "title": "Envilder Map File",
+  "description": "Maps environment variable names to cloud secret identifiers. Used by Envilder CLI, GitHub Action, and runtime SDKs to resolve secrets from AWS SSM, Azure Key Vault, and other providers.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference for IDE autocomplete and validation."
+    },
+    "$config": {
+      "type": "object",
+      "description": "Provider configuration and file metadata. All fields are optional.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "aws",
+            "azure",
+            "gcp",
+            "hashicorp",
+            "file"
+          ],
+          "default": "aws",
+          "description": "Secret provider backend. Defaults to 'aws' when absent."
+        },
+        "profile": {
+          "type": "string",
+          "description": "AWS CLI profile name for credential resolution. AWS-only."
+        },
+        "vaultUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Vault endpoint URL. Required for Azure Key Vault and HashiCorp Vault."
+        },
+        "projectId": {
+          "type": "string",
+          "description": "GCP project identifier. GCP-only."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Vault namespace. HashiCorp-only."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to .env source file for the file provider. File-only."
+        },
+        "name": {
+          "type": "string",
+          "description": "Short identifier for logs and CLI output."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this map file covers."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Responsible team or person."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Target environment (informational, ignored by runtime)."
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "aws"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "properties": {
+              "vaultUrl": false,
+              "projectId": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "azure"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "vaultUrl"
+            ],
+            "properties": {
+              "profile": false,
+              "projectId": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "gcp"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "projectId"
+            ],
+            "properties": {
+              "profile": false,
+              "vaultUrl": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "hashicorp"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "vaultUrl"
+            ],
+            "properties": {
+              "profile": false,
+              "projectId": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "file"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "profile": false,
+              "vaultUrl": false,
+              "projectId": false,
+              "namespace": false
+            }
+          }
+        }
+      ]
+    }
+  },
+  "patternProperties": {
+    "^\\$": {
+      "description": "Reserved keys. All $-prefixed keys are reserved for Envilder and ignored by parsers."
+    },
+    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+      "type": "string",
+      "description": "Variable mapping: environment variable name → secret identifier (opaque string interpreted by the provider)."
+    }
+  },
+  "additionalProperties": {
+    "type": "string",
+    "description": "Variable mapping with non-standard naming. Keys SHOULD match ^[a-zA-Z_][a-zA-Z0-9_]*$ (valid POSIX env var names) but parsers accept any non-$-prefixed string key."
+  }
+}

--- a/src/website/public/schema/map-file.v1.json
+++ b/src/website/public/schema/map-file.v1.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://envilder.com/schema/map-file.v1.json",
+  "title": "Envilder Map File",
+  "description": "Maps environment variable names to cloud secret identifiers. Used by Envilder CLI, GitHub Action, and runtime SDKs to resolve secrets from AWS SSM, Azure Key Vault, and other providers.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "JSON Schema reference for IDE autocomplete and validation."
+    },
+    "$config": {
+      "type": "object",
+      "description": "Provider configuration and file metadata. All fields are optional.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": [
+            "aws",
+            "azure",
+            "gcp",
+            "hashicorp",
+            "file"
+          ],
+          "default": "aws",
+          "description": "Secret provider backend. Defaults to 'aws' when absent."
+        },
+        "profile": {
+          "type": "string",
+          "description": "AWS CLI profile name for credential resolution. AWS-only."
+        },
+        "vaultUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Vault endpoint URL. Required for Azure Key Vault and HashiCorp Vault."
+        },
+        "projectId": {
+          "type": "string",
+          "description": "GCP project identifier. GCP-only."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Vault namespace. HashiCorp-only."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to .env source file for the file provider. File-only."
+        },
+        "name": {
+          "type": "string",
+          "description": "Short identifier for logs and CLI output."
+        },
+        "description": {
+          "type": "string",
+          "description": "What this map file covers."
+        },
+        "owner": {
+          "type": "string",
+          "description": "Responsible team or person."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Target environment (informational, ignored by runtime)."
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "aws"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "properties": {
+              "vaultUrl": false,
+              "projectId": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "azure"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "vaultUrl"
+            ],
+            "properties": {
+              "profile": false,
+              "projectId": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "gcp"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "projectId"
+            ],
+            "properties": {
+              "profile": false,
+              "vaultUrl": false,
+              "namespace": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "hashicorp"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "vaultUrl"
+            ],
+            "properties": {
+              "profile": false,
+              "projectId": false,
+              "path": false
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "provider": {
+                "const": "file"
+              }
+            },
+            "required": [
+              "provider"
+            ]
+          },
+          "then": {
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "profile": false,
+              "vaultUrl": false,
+              "projectId": false,
+              "namespace": false
+            }
+          }
+        }
+      ]
+    }
+  },
+  "patternProperties": {
+    "^\\$": {
+      "description": "Reserved keys. All $-prefixed keys are reserved for Envilder and ignored by parsers."
+    },
+    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+      "type": "string",
+      "description": "Variable mapping: environment variable name → secret identifier (opaque string interpreted by the provider)."
+    }
+  },
+  "additionalProperties": {
+    "type": "string",
+    "description": "Variable mapping with non-standard naming. Keys SHOULD match ^[a-zA-Z_][a-zA-Z0-9_]*$ (valid POSIX env var names) but parsers accept any non-$-prefixed string key."
+  }
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Adds the formal JSON Schema specification for the Envilder map-file format and publishes it via the website.

- **spec/map-file.v1.json** — Source of truth (JSON Schema draft 2020-12)
- **src/website/public/schema/map-file.v1.json** — Published copy served at envilder.com/schema/map-file.v1.json

The schema includes provider-specific conditional validation:

| Provider | Required fields | Forbidden fields |
|---|---|---|
| aws | (none) | vaultUrl, projectId, namespace, path |
| azure | vaultUrl | profile, projectId, namespace, path |
| gcp | projectId | profile, vaultUrl, namespace, path |
| hashicorp | vaultUrl | profile, projectId, path |
| file | path | profile, vaultUrl, projectId, namespace |

## Related issues

- Ref: ADR-0008 (Map-File Schema Specification)
- Follow-up: #216 (adopt envilder.json naming convention)
- Follow-up: SchemaStore.org PR (after #216)

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)
- [x] Lint/format pass

## Notes for reviewer

Schema validates all existing map files (e2e/sample/*, secrets-map.json). No runtime code changes — this is a spec-only addition plus website static file.