### PR TITLE
docs(skill): enhance grill-me with domain-awareness and doc updates

### DIFF
--- a/.github/skills/grill-me/ADR-FORMAT.md
+++ b/.github/skills/grill-me/ADR-FORMAT.md
@@ -1,7 +1,7 @@
 # ADR Format
 
-ADRs live in `docs/adr/` (or `docs/architecture/adr/`) and use sequential
-numbering: `0001-slug.md`, `0002-slug.md`, etc.
+ADRs live in `docs/adr/` and use sequential numbering:
+`0001-slug.md`, `0002-slug.md`, etc.
 
 Create the `docs/adr/` directory lazily — only when the first ADR is needed.
 

--- a/.github/skills/grill-me/ADR-FORMAT.md
+++ b/.github/skills/grill-me/ADR-FORMAT.md
@@ -1,0 +1,69 @@
+# ADR Format
+
+ADRs live in `docs/adr/` (or `docs/architecture/adr/`) and use sequential
+numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a
+decision was made and *why* — not in filling out sections.
+
+## Optional Sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by
+  ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth
+  remembering
+- **Consequences** — only when non-obvious downstream effects need to be called
+  out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to Offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and
+   wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you
+   picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not
+surprising, nobody will wonder why. If there was no real alternative, there's
+nothing to record beyond "we did the obvious thing."
+
+### What Qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is
+  event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate
+  via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth
+  provider, deployment target. Not every library — just the ones that would take
+  a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer
+  context; other contexts reference it by ID only." The explicit no-s are as
+  valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL
+  instead of an ORM because X." Anything where a reasonable reader would assume
+  the opposite. These stop the next engineer from "fixing" something that was
+  deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of
+  compliance requirements." "Response times must be under 200ms because of the
+  partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered
+  GraphQL and picked REST for subtle reasons, record it — otherwise someone will
+  suggest GraphQL again in six months.

--- a/.github/skills/grill-me/CONTEXT-FORMAT.md
+++ b/.github/skills/grill-me/CONTEXT-FORMAT.md
@@ -9,17 +9,11 @@
 
 ## Language
 
-**Order**:
-{A one or two sentence description of the term}
-_Avoid_: Purchase, transaction
-
-**Invoice**:
-A request for payment sent to a customer after delivery.
-_Avoid_: Bill, payment request
-
-**Customer**:
-A person or organization that places orders.
-_Avoid_: Client, buyer, account
+| Term | Definition | Avoid |
+|------|-----------|-------|
+| **Order** | {A one or two sentence description of the term} | Purchase, transaction |
+| **Invoice** | A request for payment sent to a customer after delivery. | Bill, payment request |
+| **Customer** | A person or organization that places orders. | Client, buyer, account |
 ```
 
 ## Rules

--- a/.github/skills/grill-me/CONTEXT-FORMAT.md
+++ b/.github/skills/grill-me/CONTEXT-FORMAT.md
@@ -1,0 +1,72 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the
+  best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not
+  what it does.
+- **Only include terms specific to this project's context.** General programming
+  concepts (timeouts, error types, utility patterns) don't belong even if the
+  project uses them extensively. Before adding a term, ask: is this a concept
+  unique to this context, or a general programming concept? Only the former
+  belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms
+  belong to a single cohesive area, a flat list is fine.
+
+## Single vs Multi-context Repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts,
+where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment
+  consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events;
+  Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is
+  resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If
+unclear, ask.

--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -1,14 +1,22 @@
 ---
 name: grill-me
 description: >-
-  Interview the user relentlessly about a plan or design until reaching shared
-  understanding. Resolves each branch of the decision tree one at a time.
-  Use when stress-testing a plan, exploring trade-offs, or validating a design.
+  Grilling session that challenges a plan against the existing domain model,
+  sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as
+  decisions crystallise. Use when stress-testing a plan, exploring trade-offs,
+  validating a design, or refining domain language.
 ---
 
 Interview me relentlessly about every aspect of this plan until we reach a
 shared understanding. Walk down each branch of the design tree, resolving
-dependencies between decisions one by one.
+dependencies between decisions one by one. For each question, provide your
+recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before
+continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase
+instead.
 
 ## Rules
 
@@ -19,3 +27,95 @@ dependencies between decisions one by one.
 - Use project domain vocabulary (map-file, provider, facade, etc.)
 - When a decision crystallizes that contradicts an existing ADR, flag it explicitly
 - Stop when all branches are resolved or user says "enough"
+
+## Domain Awareness
+
+During codebase exploration, look for existing documentation:
+
+### File structure
+
+Most repos have a single context:
+
+```
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+If a `CONTEXT-MAP.md` exists at the root, the repo has multiple contexts. The
+map points to where each one lives:
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/
+│   └── adr/                          ← system-wide decisions
+├── src/
+│   ├── ordering/
+│   │   ├── CONTEXT.md
+│   │   └── docs/adr/                 ← context-specific decisions
+│   └── billing/
+│       ├── CONTEXT.md
+│       └── docs/adr/
+```
+
+Create files lazily — only when you have something to write. If no `CONTEXT.md`
+exists, create one when the first term is resolved. If no `docs/adr/` exists,
+create it when the first ADR is needed.
+
+## During the Session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in
+`CONTEXT.md`, call it out immediately. "Your glossary defines 'cancellation' as
+X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term.
+"You're saying 'account' — do you mean the Customer or the User? Those are
+different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific
+scenarios. Invent scenarios that probe edge cases and force the user to be
+precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you
+find a contradiction, surface it: "Your code cancels entire Orders, but you just
+said partial cancellation is possible — which is right?"
+
+### Update CONTEXT.md inline
+
+When a term is resolved, update `CONTEXT.md` right there. Don't batch these
+up — capture them as they happen. Use the format in
+[CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
+
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat
+`CONTEXT.md` as a spec, a scratch pad, or a repository for implementation
+decisions. It is a glossary and nothing else.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they
+   do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you
+   picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Use the format in
+[ADR-FORMAT.md](./ADR-FORMAT.md).
+
+---
+
+_Based on [grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) by [Matt Pocock](https://github.com/mattpocock)._

--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -23,7 +23,7 @@ instead.
 - Ask questions **one at a time**
 - For each question, provide your **recommended answer** with brief rationale
 - If a question can be answered by **exploring the codebase**, explore it instead of asking
-- Reference existing ADRs in `docs/architecture/adr/` — don't re-litigate settled decisions
+- Reference existing ADRs in `docs/adr/` — don't re-litigate settled decisions
 - Use project domain vocabulary (map-file, provider, facade, etc.)
 - When a decision crystallizes that contradicts an existing ADR, flag it explicitly
 - Stop when all branches are resolved or user says "enough"


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Enhances the existing `grill-me` skill by merging domain-awareness and inline documentation behaviors from Matt Pocock's [`grill-with-docs`](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) skill.

Added capabilities:
- Challenge user terminology against existing `CONTEXT.md` glossary
- Sharpen fuzzy/overloaded language into precise canonical terms
- Stress-test domain relationships with concrete edge-case scenarios
- Cross-reference user statements against actual code
- Inline `CONTEXT.md` updates as terms are resolved
- Offer ADRs sparingly (only when hard to reverse, surprising, and a real trade-off)

New supporting files:
- `CONTEXT-FORMAT.md` — Template and rules for maintaining a domain glossary
- `ADR-FORMAT.md` — Minimal ADR template with qualification criteria

## Related issues

N/A

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Checklist

- [ ] Tests added/updated (if needed)
- [x] Docs updated (if needed)
- [x] Lint/format pass

## Notes for reviewer

Based on [grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) by [@mattpocock](https://github.com/mattpocock). Attribution included in SKILL.md footer and via `Co-authored-by` commit trailer.
