### PR TITLE
feat(website): reposition homepage around standardized secret consumption

### DIFF
--- a/src/website/src/components/BeforeAfter.astro
+++ b/src/website/src/components/BeforeAfter.astro
@@ -1,0 +1,127 @@
+---
+import { useTranslations } from '../i18n/utils';
+
+interface Props {
+  lang?: string;
+}
+
+const { lang = 'en' } = Astro.props;
+const t = useTranslations(lang);
+---
+
+<section class="section" id="before-after">
+  <div class="container">
+    <div class="section-title">
+      <h2>{t.beforeAfter.title}<span>{t.beforeAfter.titleAccent}</span></h2>
+      <p class="section-subtitle">
+        {t.beforeAfter.subtitle}
+      </p>
+    </div>
+
+    <div class="comparison">
+      <div class="comparison-column comparison-without">
+        <h3 class="comparison-heading comparison-heading-without">
+          {t.beforeAfter.columnWithout}
+        </h3>
+        <ul class="comparison-list">
+          {t.beforeAfter.rows.map((row) => (
+            <li class="comparison-item">{row.without}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div class="comparison-column comparison-with">
+        <h3 class="comparison-heading comparison-heading-with">
+          {t.beforeAfter.columnWith}
+        </h3>
+        <ul class="comparison-list">
+          {t.beforeAfter.rows.map((row) => (
+            <li class="comparison-item">{row.with}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .comparison {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-lg);
+    margin-top: var(--space-2xl);
+  }
+
+  @media (min-width: 768px) {
+    .comparison {
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-xl);
+    }
+  }
+
+  .comparison-column {
+    border: 1px solid var(--color-border);
+    padding: var(--space-xl);
+    background: var(--color-surface);
+  }
+
+  .comparison-without {
+    border-color: var(--color-error);
+  }
+
+  .comparison-with {
+    border-color: var(--color-success);
+  }
+
+  .comparison-heading {
+    font-family: var(--font-pixel);
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-sm);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .comparison-heading-without {
+    color: var(--color-error);
+    border-bottom-color: var(--color-error);
+  }
+
+  .comparison-heading-with {
+    color: var(--color-success);
+    border-bottom-color: var(--color-success);
+  }
+
+  .comparison-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .comparison-item {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    padding-left: var(--space-md);
+    position: relative;
+  }
+
+  .comparison-without .comparison-item::before {
+    content: '✗';
+    position: absolute;
+    left: 0;
+    color: var(--color-error);
+    font-weight: bold;
+  }
+
+  .comparison-with .comparison-item::before {
+    content: '✓';
+    position: absolute;
+    left: 0;
+    color: var(--color-success);
+    font-weight: bold;
+  }
+</style>

--- a/src/website/src/components/BeforeAfter.astro
+++ b/src/website/src/components/BeforeAfter.astro
@@ -18,51 +18,78 @@ const t = useTranslations(lang);
       </p>
     </div>
 
-    <div class="comparison">
-      <div class="comparison-column comparison-without">
-        <h3 class="comparison-heading comparison-heading-without">
-          {t.beforeAfter.columnWithout}
-        </h3>
-        <ul class="comparison-list">
-          {t.beforeAfter.rows.map((row) => (
-            <li class="comparison-item">{row.without}</li>
-          ))}
-        </ul>
-      </div>
+    <div class="comparison-headers">
+      <h3 class="comparison-heading comparison-heading-without">
+        {t.beforeAfter.columnWithout}
+      </h3>
+      <h3 class="comparison-heading comparison-heading-with">
+        {t.beforeAfter.columnWith}
+      </h3>
+    </div>
 
-      <div class="comparison-column comparison-with">
-        <h3 class="comparison-heading comparison-heading-with">
-          {t.beforeAfter.columnWith}
-        </h3>
-        <ul class="comparison-list">
-          {t.beforeAfter.rows.map((row) => (
-            <li class="comparison-item">{row.with}</li>
-          ))}
-        </ul>
-      </div>
+    <div class="comparison">
+      {t.beforeAfter.rows.map((row) => (
+        <div class="comparison-row">
+          <div class="comparison-card comparison-without">
+            <span class="status-icon">✗</span>
+            <p class="comparison-text">{row.without}</p>
+          </div>
+          <div class="comparison-card comparison-with">
+            <span class="status-icon">✓</span>
+            <p class="comparison-text">{row.with}</p>
+          </div>
+        </div>
+      ))}
     </div>
   </div>
 </section>
 
 <style>
   .comparison {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
     margin-top: var(--space-2xl);
   }
 
+  .comparison-headers {
+    display: none;
+  }
+
   @media (min-width: 768px) {
+    .comparison-headers {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-xl);
+      margin-top: var(--space-2xl);
+      margin-bottom: var(--space-md);
+    }
+
     .comparison {
+      margin-top: 0;
+    }
+  }
+
+  .comparison-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+
+  @media (min-width: 768px) {
+    .comparison-row {
       grid-template-columns: 1fr 1fr;
       gap: var(--space-xl);
     }
   }
 
-  .comparison-column {
+  .comparison-card {
     border: 1px solid var(--color-border);
-    padding: var(--space-xl);
+    padding: var(--space-lg);
     background: var(--color-surface);
+    display: flex;
+    gap: var(--space-md);
+    align-items: flex-start;
   }
 
   .comparison-without {
@@ -78,7 +105,6 @@ const t = useTranslations(lang);
     font-size: 0.7rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
-    margin-bottom: var(--space-lg);
     padding-bottom: var(--space-sm);
     border-bottom: 1px solid var(--color-border);
   }
@@ -93,35 +119,24 @@ const t = useTranslations(lang);
     border-bottom-color: var(--color-success);
   }
 
-  .comparison-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-md);
+  .status-icon {
+    font-weight: bold;
+    font-size: 1.1rem;
+    flex-shrink: 0;
+    line-height: 1;
   }
 
-  .comparison-item {
+  .comparison-without .status-icon {
+    color: var(--color-error);
+  }
+
+  .comparison-with .status-icon {
+    color: var(--color-success);
+  }
+
+  .comparison-text {
     font-size: 0.9rem;
     line-height: 1.6;
-    padding-left: var(--space-md);
-    position: relative;
-  }
-
-  .comparison-without .comparison-item::before {
-    content: '✗';
-    position: absolute;
-    left: 0;
-    color: var(--color-error);
-    font-weight: bold;
-  }
-
-  .comparison-with .comparison-item::before {
-    content: '✓';
-    position: absolute;
-    left: 0;
-    color: var(--color-success);
-    font-weight: bold;
+    margin: 0;
   }
 </style>

--- a/src/website/src/components/Hero.astro
+++ b/src/website/src/components/Hero.astro
@@ -26,8 +26,12 @@ const version = `v${__APP_VERSION__}`;
       </h1>
 
       <p class="hero-description">
-        {t.hero.description}<strong>{t.hero.descAws}</strong> {t.hero.descOr} <strong>{t.hero.descAzure}</strong>{t.hero.descSuffix}
+        {t.hero.description}
       </p>
+
+      <div class="hero-tech-line">
+        <strong>{t.hero.descAws}</strong> {t.hero.descOr} <strong>{t.hero.descAzure}</strong>{t.hero.descSuffix}
+      </div>
 
       <div class="hero-actions">
         <a href="#get-started" class="btn btn-primary">
@@ -165,6 +169,17 @@ const version = `v${__APP_VERSION__}`;
   }
 
   .hero-description strong {
+    color: var(--color-secondary);
+  }
+
+  .hero-tech-line {
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    letter-spacing: 0.02em;
+  }
+
+  .hero-tech-line strong {
     color: var(--color-secondary);
   }
 

--- a/src/website/src/components/Hero.astro
+++ b/src/website/src/components/Hero.astro
@@ -174,7 +174,7 @@ const version = `v${__APP_VERSION__}`;
 
   .hero-tech-line {
     font-size: 0.85rem;
-    color: var(--color-muted);
+    color: var(--color-text-muted);
     font-family: var(--font-mono);
     letter-spacing: 0.02em;
   }

--- a/src/website/src/components/Sponsors.astro
+++ b/src/website/src/components/Sponsors.astro
@@ -34,6 +34,8 @@ const t = useTranslations(lang);
       target="_blank"
       rel="noopener noreferrer"
       class="sponsor-link aws-credits-link"
+      title={t.sponsors.awsCreditsAlt}
+      aria-label={t.sponsors.awsCreditsAlt}
     >
       <span class="aws-credits-badge">{t.sponsors.awsCreditsLabel}</span>
     </a>

--- a/src/website/src/components/Sponsors.astro
+++ b/src/website/src/components/Sponsors.astro
@@ -29,6 +29,14 @@ const t = useTranslations(lang);
         alt={t.sponsors.localstackAlt}
       />
     </a>
+    <a
+      href="https://aws.amazon.com/blogs/opensource/aws-cloud-credits-for-open-source-projects-affirming-our-commitment/"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="sponsor-link aws-credits-link"
+    >
+      <span class="aws-credits-badge">{t.sponsors.awsCreditsLabel}</span>
+    </a>
   </div>
 </section>
 
@@ -64,6 +72,21 @@ const t = useTranslations(lang);
 
   .sponsor-link:hover {
     opacity: 1;
+  }
+
+  .aws-credits-badge {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    padding: var(--space-xs) var(--space-sm);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+
+  .aws-credits-link:hover .aws-credits-badge {
+    color: var(--color-text);
+    border-color: var(--color-primary);
   }
 
   .sponsor-logo {

--- a/src/website/src/i18n/ca.ts
+++ b/src/website/src/i18n/ca.ts
@@ -2,9 +2,10 @@ import type { Translations } from './types';
 
 export const ca: Translations = {
   homeMeta: {
-    title: 'Envilder: un model per resoldre secrets a cada entorn i runtime.',
+    title:
+      'Envilder: estandarditza com les teves aplicacions consumeixen secrets a cada entorn i runtime.',
     description:
-      "Un sistema de resolució de configuració basat en un model. Defineix els mapeigs de secrets una vegada i resol-los de forma consistent: CLI, CI/CD o runtime d'aplicació. Basat en AWS SSM, Azure Key Vault i GCP Secret Manager.",
+      "Defineix el contracte d'entorn una vegada i resol-lo de forma consistent en desenvolupament local, CI/CD i runtime. Amb AWS SSM Parameter Store i Azure Key Vault.",
   },
   nav: {
     features: 'Funcionalitats',
@@ -30,20 +31,20 @@ export const ca: Translations = {
     ariaTheme: 'Tema',
   },
   hero: {
-    openSource: 'Codi obert · MIT',
-    title1: 'El fitxer .env és',
-    title2: 'un incident de seguretat',
-    titleAccent: 'esperant a passar.',
-    description: "Envilder llegeix els teus secrets directament d'",
-    descAws: 'AWS',
-    descAzure: 'Azure',
-    descOr: 'o',
-    descSuffix:
-      ' cap a la teva app. Sense fitxers, sense SaaS, sense filtracions.',
+    openSource: 'Codi obert · MIT · AWS SSM · Azure Key Vault',
+    title1: 'Estandarditza com',
+    title2: 'les teves apps consumeixen',
+    titleAccent: 'secrets.',
+    description:
+      'Deixa de reinventar la càrrega de secrets a cada projecte. Defineix un contracte d\'entorn i resol-lo a tot arreu.',
+    descAws: 'AWS SSM',
+    descAzure: 'Azure Key Vault',
+    descOr: '·',
+    descSuffix: ' · GitHub Action · SDKs de runtime',
     getStarted: '▶ Comença',
     viewOnGithub: '★ Veure a GitHub',
-    terminalComment1: '# 1. Un model de mapeig per a cada entorn',
-    terminalComment2: '# 2. Resol secrets amb la CLI',
+    terminalComment1: "# 1. Un contracte d'entorn per app",
+    terminalComment2: '# 2. Resol el contracte',
     terminalFetched1: ' Obtingut DB_PASSWORD → ···pass',
     terminalFetched2: ' Obtingut API_KEY     → ···key',
     terminalWritten: " Fitxer d'entorn escrit a .env",
@@ -54,6 +55,8 @@ export const ca: Translations = {
   sponsors: {
     title: 'Sponsors',
     localstackAlt: 'LocalStack',
+    awsCreditsAlt: 'AWS Open Source Credits Program',
+    awsCreditsLabel: 'AWS Open Source Credits',
   },
   problemSolution: {
     title: 'Per què la gestió de secrets ',
@@ -100,6 +103,36 @@ export const ca: Translations = {
         title: 'El teu núvol, sense intermediaris',
         description:
           "AWS SSM, Azure Key Vault o GCP. Sense proxy SaaS. Els secrets es queden a la teva infraestructura. Control d'accés natiu IAM/RBAC.",
+      },
+    ],
+  },
+  beforeAfter: {
+    title: 'Sense un estàndard, ',
+    titleAccent: 'cada projecte deriva.',
+    subtitle:
+      'Envilder converteix convencions disperses de càrrega de secrets en un contracte versionat que funciona en desenvolupament, pipelines i runtime.',
+    columnWithout: 'Sense un estàndard',
+    columnWith: 'Amb Envilder',
+    rows: [
+      {
+        without:
+          'Els developers copien fitxers .env o segueixen READMEs desactualitzats.',
+        with: "Un contracte declara quins secrets necessita l'aplicació.",
+      },
+      {
+        without:
+          'CI/CD té els seus propis noms de secrets i integracions.',
+        with: 'El mateix contracte es resol a GitHub Actions.',
+      },
+      {
+        without:
+          'Cada app implementa la seva pròpia lògica de càrrega.',
+        with: 'Els SDKs de runtime carreguen des del mateix contracte.',
+      },
+      {
+        without:
+          'La configuració real queda dispersa en coneixement tribal.',
+        with: 'El contracte viu a Git i es pot revisar en PRs.',
       },
     ],
   },

--- a/src/website/src/i18n/ca.ts
+++ b/src/website/src/i18n/ca.ts
@@ -36,7 +36,7 @@ export const ca: Translations = {
     title2: 'les teves apps consumeixen',
     titleAccent: 'secrets.',
     description:
-      'Deixa de reinventar la càrrega de secrets a cada projecte. Defineix un contracte d\'entorn i resol-lo a tot arreu.',
+      "Deixa de reinventar la càrrega de secrets a cada projecte. Defineix un contracte d'entorn i resol-lo a tot arreu.",
     descAws: 'AWS SSM',
     descAzure: 'Azure Key Vault',
     descOr: '·',
@@ -120,18 +120,15 @@ export const ca: Translations = {
         with: "Un contracte declara quins secrets necessita l'aplicació.",
       },
       {
-        without:
-          'CI/CD té els seus propis noms de secrets i integracions.',
+        without: 'CI/CD té els seus propis noms de secrets i integracions.',
         with: 'El mateix contracte es resol a GitHub Actions.',
       },
       {
-        without:
-          'Cada app implementa la seva pròpia lògica de càrrega.',
+        without: 'Cada app implementa la seva pròpia lògica de càrrega.',
         with: 'Els SDKs de runtime carreguen des del mateix contracte.',
       },
       {
-        without:
-          'La configuració real queda dispersa en coneixement tribal.',
+        without: 'La configuració real queda dispersa en coneixement tribal.',
         with: 'El contracte viu a Git i es pot revisar en PRs.',
       },
     ],

--- a/src/website/src/i18n/en.ts
+++ b/src/website/src/i18n/en.ts
@@ -115,23 +115,19 @@ export const en: Translations = {
     columnWith: 'With Envilder',
     rows: [
       {
-        without:
-          'Developers copy .env files or follow outdated READMEs.',
+        without: 'Developers copy .env files or follow outdated READMEs.',
         with: 'One contract declares what secrets the app needs.',
       },
       {
-        without:
-          'CI/CD has its own secret names and integration.',
+        without: 'CI/CD has its own secret names and integration.',
         with: 'The same contract resolves in GitHub Actions.',
       },
       {
-        without:
-          'Each app implements its own loading logic.',
+        without: 'Each app implements its own loading logic.',
         with: 'Runtime SDKs load from the same contract.',
       },
       {
-        without:
-          'The real config is scattered across tribal knowledge.',
+        without: 'The real config is scattered across tribal knowledge.',
         with: 'The contract is in Git, reviewable in PRs.',
       },
     ],

--- a/src/website/src/i18n/en.ts
+++ b/src/website/src/i18n/en.ts
@@ -3,9 +3,9 @@ import type { Translations } from './types';
 export const en: Translations = {
   homeMeta: {
     title:
-      'Envilder: one model to resolve secrets across every environment and runtime.',
+      'Envilder: standardize how your applications consume secrets across every environment and runtime.',
     description:
-      'A model-driven configuration resolution system. Define secret mappings once and resolve them consistently: CLI, CI/CD, or application runtime. Powered by AWS SSM, Azure Key Vault, and GCP Secret Manager.',
+      'Define your environment contract once and resolve it consistently across local development, CI/CD, and runtime. Using AWS SSM Parameter Store and Azure Key Vault.',
   },
   nav: {
     features: 'Features',
@@ -31,19 +31,20 @@ export const en: Translations = {
     ariaTheme: 'Theme',
   },
   hero: {
-    openSource: 'Open Source · MIT',
-    title1: 'The .env file is',
-    title2: 'a security incident',
-    titleAccent: 'waiting to happen.',
-    description: 'Envilder pulls secrets from ',
-    descAws: 'AWS',
-    descAzure: 'Azure',
-    descOr: 'or',
-    descSuffix: ' straight into your app. No files, no SaaS, no leaks.',
+    openSource: 'Open Source · MIT · AWS SSM · Azure Key Vault',
+    title1: 'Standardize how',
+    title2: 'your apps consume',
+    titleAccent: 'secrets.',
+    description:
+      'Stop reinventing secret loading in every project. Define one environment contract and resolve it everywhere.',
+    descAws: 'AWS SSM',
+    descAzure: 'Azure Key Vault',
+    descOr: '·',
+    descSuffix: ' · GitHub Action · Runtime SDKs',
     getStarted: '▶ Get started',
     viewOnGithub: '★ View on GitHub',
-    terminalComment1: '# 1. One mapping model for every environment',
-    terminalComment2: '# 2. Resolve secrets with the CLI',
+    terminalComment1: '# 1. One environment contract per app',
+    terminalComment2: '# 2. Resolve the contract',
     terminalFetched1: ' Fetched DB_PASSWORD → ···pass',
     terminalFetched2: ' Fetched API_KEY     → ···key',
     terminalWritten: ' Environment file written to .env',
@@ -54,6 +55,8 @@ export const en: Translations = {
   sponsors: {
     title: 'Sponsors',
     localstackAlt: 'LocalStack',
+    awsCreditsAlt: 'AWS Open Source Credits Program',
+    awsCreditsLabel: 'AWS Open Source Credits',
   },
   problemSolution: {
     title: 'Why secret management ',
@@ -100,6 +103,36 @@ export const en: Translations = {
         title: 'Your cloud, no middleman',
         description:
           'AWS SSM, Azure Key Vault, or GCP. No SaaS proxy. Secrets stay in your infrastructure. Native IAM/RBAC access control.',
+      },
+    ],
+  },
+  beforeAfter: {
+    title: 'Without a standard, ',
+    titleAccent: 'every project drifts.',
+    subtitle:
+      'Envilder turns scattered secret-loading conventions into one versioned contract that works across development, pipelines, and runtime.',
+    columnWithout: 'Without a standard',
+    columnWith: 'With Envilder',
+    rows: [
+      {
+        without:
+          'Developers copy .env files or follow outdated READMEs.',
+        with: 'One contract declares what secrets the app needs.',
+      },
+      {
+        without:
+          'CI/CD has its own secret names and integration.',
+        with: 'The same contract resolves in GitHub Actions.',
+      },
+      {
+        without:
+          'Each app implements its own loading logic.',
+        with: 'Runtime SDKs load from the same contract.',
+      },
+      {
+        without:
+          'The real config is scattered across tribal knowledge.',
+        with: 'The contract is in Git, reviewable in PRs.',
       },
     ],
   },

--- a/src/website/src/i18n/es.ts
+++ b/src/website/src/i18n/es.ts
@@ -120,18 +120,15 @@ export const es: Translations = {
         with: 'Un contrato declara qué secretos necesita la aplicación.',
       },
       {
-        without:
-          'CI/CD tiene sus propios nombres de secretos e integraciones.',
+        without: 'CI/CD tiene sus propios nombres de secretos e integraciones.',
         with: 'El mismo contrato se resuelve en GitHub Actions.',
       },
       {
-        without:
-          'Cada app implementa su propia lógica de carga.',
+        without: 'Cada app implementa su propia lógica de carga.',
         with: 'Los SDKs de runtime cargan desde el mismo contrato.',
       },
       {
-        without:
-          'La configuración real queda dispersa en conocimiento tribal.',
+        without: 'La configuración real queda dispersa en conocimiento tribal.',
         with: 'El contrato vive en Git y se puede revisar en PRs.',
       },
     ],

--- a/src/website/src/i18n/es.ts
+++ b/src/website/src/i18n/es.ts
@@ -3,9 +3,9 @@ import type { Translations } from './types';
 export const es: Translations = {
   homeMeta: {
     title:
-      'Envilder: un modelo para resolver secretos en cada entorno y runtime.',
+      'Envilder: estandariza cómo tus aplicaciones consumen secretos en cada entorno y runtime.',
     description:
-      'Un sistema de resolución de configuración basado en un modelo. Define los mapeos de secretos una vez y resuélvelos de forma consistente: CLI, CI/CD o runtime de aplicación. Basado en AWS SSM, Azure Key Vault y GCP Secret Manager.',
+      'Define tu contrato de entorno una vez y resuélvelo de forma consistente en desarrollo local, CI/CD y runtime. Con AWS SSM Parameter Store y Azure Key Vault.',
   },
   nav: {
     features: 'Funcionalidades',
@@ -31,19 +31,20 @@ export const es: Translations = {
     ariaTheme: 'Tema',
   },
   hero: {
-    openSource: 'Código abierto · MIT',
-    title1: 'El archivo .env es',
-    title2: 'un incidente de seguridad',
-    titleAccent: 'esperando a pasar.',
-    description: 'Envilder lee tus secretos directamente de ',
-    descAws: 'AWS',
-    descAzure: 'Azure',
-    descOr: 'o',
-    descSuffix: ' hacia tu app. Sin archivos, sin SaaS, sin filtraciones.',
+    openSource: 'Código abierto · MIT · AWS SSM · Azure Key Vault',
+    title1: 'Estandariza cómo',
+    title2: 'tus apps consumen',
+    titleAccent: 'secretos.',
+    description:
+      'Deja de reinventar la carga de secretos en cada proyecto. Define un contrato de entorno y resuélvelo en todas partes.',
+    descAws: 'AWS SSM',
+    descAzure: 'Azure Key Vault',
+    descOr: '·',
+    descSuffix: ' · GitHub Action · SDKs de runtime',
     getStarted: '▶ Empezar',
     viewOnGithub: '★ Ver en GitHub',
-    terminalComment1: '# 1. Un modelo de mapeo para cada entorno',
-    terminalComment2: '# 2. Resuelve secretos con la CLI',
+    terminalComment1: '# 1. Un contrato de entorno por app',
+    terminalComment2: '# 2. Resuelve el contrato',
     terminalFetched1: ' Obtenido DB_PASSWORD → ···pass',
     terminalFetched2: ' Obtenido API_KEY     → ···key',
     terminalWritten: ' Archivo de entorno escrito en .env',
@@ -54,6 +55,8 @@ export const es: Translations = {
   sponsors: {
     title: 'Sponsors',
     localstackAlt: 'LocalStack',
+    awsCreditsAlt: 'AWS Open Source Credits Program',
+    awsCreditsLabel: 'AWS Open Source Credits',
   },
   problemSolution: {
     title: 'Por qué la gestión de secretos ',
@@ -100,6 +103,36 @@ export const es: Translations = {
         title: 'Tu nube, sin intermediarios',
         description:
           'AWS SSM, Azure Key Vault o GCP. Sin proxy SaaS. Los secretos se quedan en tu infraestructura. Control de acceso nativo IAM/RBAC.',
+      },
+    ],
+  },
+  beforeAfter: {
+    title: 'Sin un estándar, ',
+    titleAccent: 'cada proyecto deriva.',
+    subtitle:
+      'Envilder convierte convenciones dispersas de carga de secretos en un contrato versionado que funciona en desarrollo, pipelines y runtime.',
+    columnWithout: 'Sin un estándar',
+    columnWith: 'Con Envilder',
+    rows: [
+      {
+        without:
+          'Los developers copian archivos .env o siguen READMEs desactualizados.',
+        with: 'Un contrato declara qué secretos necesita la aplicación.',
+      },
+      {
+        without:
+          'CI/CD tiene sus propios nombres de secretos e integraciones.',
+        with: 'El mismo contrato se resuelve en GitHub Actions.',
+      },
+      {
+        without:
+          'Cada app implementa su propia lógica de carga.',
+        with: 'Los SDKs de runtime cargan desde el mismo contrato.',
+      },
+      {
+        without:
+          'La configuración real queda dispersa en conocimiento tribal.',
+        with: 'El contrato vive en Git y se puede revisar en PRs.',
       },
     ],
   },

--- a/src/website/src/i18n/types.ts
+++ b/src/website/src/i18n/types.ts
@@ -510,6 +510,22 @@ export interface HomeMetaTranslations {
 export interface SponsorsTranslations {
   title: string;
   localstackAlt: string;
+  awsCreditsAlt: string;
+  awsCreditsLabel: string;
+}
+
+export interface BeforeAfterRow {
+  without: string;
+  with: string;
+}
+
+export interface BeforeAfterTranslations {
+  title: string;
+  titleAccent: string;
+  subtitle: string;
+  columnWithout: string;
+  columnWith: string;
+  rows: BeforeAfterRow[];
 }
 
 export interface Translations {
@@ -520,6 +536,7 @@ export interface Translations {
   trust: TrustTranslations;
   sponsors: SponsorsTranslations;
   problemSolution: ProblemSolutionTranslations;
+  beforeAfter: BeforeAfterTranslations;
   howItWorks: HowItWorksTranslations;
   features: FeaturesTranslations;
   demo: DemoTranslations;

--- a/src/website/src/pages/ca/index.astro
+++ b/src/website/src/pages/ca/index.astro
@@ -1,4 +1,5 @@
 ---
+import BeforeAfter from '../../components/BeforeAfter.astro';
 import DemoVideo from '../../components/DemoVideo.astro';
 import FeaturesGrid from '../../components/FeaturesGrid.astro';
 import Footer from '../../components/Footer.astro';
@@ -7,7 +8,6 @@ import GitHubAction from '../../components/GitHubAction.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
-import BeforeAfter from '../../components/BeforeAfter.astro';
 import ProblemSolution from '../../components/ProblemSolution.astro';
 import Providers from '../../components/Providers.astro';
 import Roadmap from '../../components/Roadmap.astro';

--- a/src/website/src/pages/ca/index.astro
+++ b/src/website/src/pages/ca/index.astro
@@ -7,6 +7,7 @@ import GitHubAction from '../../components/GitHubAction.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
+import BeforeAfter from '../../components/BeforeAfter.astro';
 import ProblemSolution from '../../components/ProblemSolution.astro';
 import Providers from '../../components/Providers.astro';
 import Roadmap from '../../components/Roadmap.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <TrustBadges lang={lang} />
     <Sponsors lang={lang} />
     <ProblemSolution lang={lang} />
+    <BeforeAfter lang={lang} />
     <FeaturesGrid lang={lang} />
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />

--- a/src/website/src/pages/es/index.astro
+++ b/src/website/src/pages/es/index.astro
@@ -1,4 +1,5 @@
 ---
+import BeforeAfter from '../../components/BeforeAfter.astro';
 import DemoVideo from '../../components/DemoVideo.astro';
 import FeaturesGrid from '../../components/FeaturesGrid.astro';
 import Footer from '../../components/Footer.astro';
@@ -7,7 +8,6 @@ import GitHubAction from '../../components/GitHubAction.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
-import BeforeAfter from '../../components/BeforeAfter.astro';
 import ProblemSolution from '../../components/ProblemSolution.astro';
 import Providers from '../../components/Providers.astro';
 import Roadmap from '../../components/Roadmap.astro';

--- a/src/website/src/pages/es/index.astro
+++ b/src/website/src/pages/es/index.astro
@@ -7,6 +7,7 @@ import GitHubAction from '../../components/GitHubAction.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
+import BeforeAfter from '../../components/BeforeAfter.astro';
 import ProblemSolution from '../../components/ProblemSolution.astro';
 import Providers from '../../components/Providers.astro';
 import Roadmap from '../../components/Roadmap.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <TrustBadges lang={lang} />
     <Sponsors lang={lang} />
     <ProblemSolution lang={lang} />
+    <BeforeAfter lang={lang} />
     <FeaturesGrid lang={lang} />
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />

--- a/src/website/src/pages/index.astro
+++ b/src/website/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import BeforeAfter from '../components/BeforeAfter.astro';
 import DemoVideo from '../components/DemoVideo.astro';
 import FeaturesGrid from '../components/FeaturesGrid.astro';
 import Footer from '../components/Footer.astro';
@@ -7,7 +8,6 @@ import GitHubAction from '../components/GitHubAction.astro';
 import Hero from '../components/Hero.astro';
 import HowItWorks from '../components/HowItWorks.astro';
 import Navbar from '../components/Navbar.astro';
-import BeforeAfter from '../components/BeforeAfter.astro';
 import ProblemSolution from '../components/ProblemSolution.astro';
 import Providers from '../components/Providers.astro';
 import Roadmap from '../components/Roadmap.astro';

--- a/src/website/src/pages/index.astro
+++ b/src/website/src/pages/index.astro
@@ -7,6 +7,7 @@ import GitHubAction from '../components/GitHubAction.astro';
 import Hero from '../components/Hero.astro';
 import HowItWorks from '../components/HowItWorks.astro';
 import Navbar from '../components/Navbar.astro';
+import BeforeAfter from '../components/BeforeAfter.astro';
 import ProblemSolution from '../components/ProblemSolution.astro';
 import Providers from '../components/Providers.astro';
 import Roadmap from '../components/Roadmap.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <TrustBadges lang={lang} />
     <Sponsors lang={lang} />
     <ProblemSolution lang={lang} />
+    <BeforeAfter lang={lang} />
     <FeaturesGrid lang={lang} />
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />


### PR DESCRIPTION
## Description

Repositions the Envilder homepage messaging from '.env security incident' to 'standardize how apps consume secrets'. This is a strategic positioning change that better communicates Envilder's real value as a secret consumption standard.

## Type of Change
- [x] New feature
- [x] Documentation update

## Changes Made

### Hero (all 3 locales)
- H1: 'Standardize how your apps consume secrets.'
- Description: 'Stop reinventing secret loading in every project. Define one environment contract and resolve it everywhere.'
- Badge line updated: Open Source · MIT · AWS SSM · Azure Key Vault
- Tech line added below description: AWS SSM · Azure Key Vault · GitHub Action · Runtime SDKs
- Terminal comments: 'One environment contract per app' / 'Resolve the contract'

### New BeforeAfter section
- Two-column comparison: 'Without a standard' vs 'With Envilder'
- 4 rows: local dev, CI/CD, runtime loading, tribal knowledge
- Placed between ProblemSolution and FeaturesGrid
- Responsive: stacked mobile, 2 columns desktop
- Consistent styling (error/success colors, pixel font headings)

### Sponsors section
- Added AWS Open Source Credits Program badge next to LocalStack logo

### Files
- \src/website/src/i18n/types.ts\ — BeforeAfterTranslations + SponsorsTranslations updated
- \src/website/src/i18n/{en,ca,es}.ts\ — hero + beforeAfter + sponsors
- \src/website/src/components/Hero.astro\ — description + tech line
- \src/website/src/components/BeforeAfter.astro\ — new component
- \src/website/src/components/Sponsors.astro\ — AWS credits badge
- \src/website/src/pages/{index,ca/index,es/index}.astro\ — BeforeAfter import

## Checklist
- [x] Code follows project conventions
- [x] Build passes locally (\pnpm build\ ✓)
- [x] All 3 locales updated (en, ca, es)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a before/after comparison section to the homepage highlighting key benefits.
  * Added an AWS Open Source Credits sponsor badge.

* **Improvements**
  * Updated hero section messaging and presentation.
  * Refreshed homepage content and translations for English, Spanish, and Catalan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->