### PR TITLE
fix(website): restore Get started section and tighten hero terminal height

### DIFF
--- a/src/website/src/components/Hero.astro
+++ b/src/website/src/components/Hero.astro
@@ -568,7 +568,7 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
 
   .hero-term-screen {
     display: block;
-    min-height: 27em;
+    min-height: 21em;
   }
 
   .hero-term-screen :global(.line) {

--- a/src/website/src/pages/ca/index.astro
+++ b/src/website/src/pages/ca/index.astro
@@ -2,6 +2,7 @@
 import DemoVideo from '../../components/DemoVideo.astro';
 import FeaturesGrid from '../../components/FeaturesGrid.astro';
 import Footer from '../../components/Footer.astro';
+import GetStarted from '../../components/GetStarted.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />
     <Providers lang={lang} />
+    <GetStarted lang={lang} />
   </main>
   <Footer lang={lang} />
 </BaseLayout>

--- a/src/website/src/pages/es/index.astro
+++ b/src/website/src/pages/es/index.astro
@@ -2,6 +2,7 @@
 import DemoVideo from '../../components/DemoVideo.astro';
 import FeaturesGrid from '../../components/FeaturesGrid.astro';
 import Footer from '../../components/Footer.astro';
+import GetStarted from '../../components/GetStarted.astro';
 import Hero from '../../components/Hero.astro';
 import HowItWorks from '../../components/HowItWorks.astro';
 import Navbar from '../../components/Navbar.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />
     <Providers lang={lang} />
+    <GetStarted lang={lang} />
   </main>
   <Footer lang={lang} />
 </BaseLayout>

--- a/src/website/src/pages/index.astro
+++ b/src/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import DemoVideo from '../components/DemoVideo.astro';
 import FeaturesGrid from '../components/FeaturesGrid.astro';
 import Footer from '../components/Footer.astro';
+import GetStarted from '../components/GetStarted.astro';
 import Hero from '../components/Hero.astro';
 import HowItWorks from '../components/HowItWorks.astro';
 import Navbar from '../components/Navbar.astro';
@@ -31,6 +32,7 @@ const t = useTranslations(lang);
     <HowItWorks lang={lang} />
     <DemoVideo lang={lang} />
     <Providers lang={lang} />
+    <GetStarted lang={lang} />
   </main>
   <Footer lang={lang} />
 </BaseLayout>


### PR DESCRIPTION
## Summary

Fixes two issues reported on the live site after PR #311 was merged: the
hero "Get started" button did nothing, and the hero terminal showed a large
empty dark area below short scenes.

## Changes

- fix(website): re-add the `GetStarted` component to the en/ca/es home pages.
  The hero button links to `#get-started`, but the section was not rendered
  on the home page, so the anchor pointed nowhere. The component already
  existed and is fully translated; it was just disconnected from the page.
- fix(website): reduce the hero terminal `min-height` from `27em` to `21em`
  so short scenes (CLI, Node.js, Python, .NET) no longer leave a big empty
  void below the content, which was especially visible on the light theme.

## Testing

- [x] `pnpm lint` passes
- [x] Manual verification (clicked the hero "Get started" button locally and
  confirmed it scrolls to the Get started section; checked the reduced
  terminal void across scenes and widths in the browser)

## Related

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Get Started" section to the homepage across multiple language versions.

* **Style**
  * Reduced the minimum height of the hero terminal display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->