### PR TITLE
feat(ci): add stack, type and size PR auto-labeler

### DIFF
--- a/.github/workflows/labeler/size.yml
+++ b/.github/workflows/labeler/size.yml
@@ -1,0 +1,39 @@
+# PR size labeling — parametrizable thresholds for the label-by-size job
+# in .github/workflows/pr-labeler.yml.
+#
+# Model: the changed-line count sets the BASE size. If the change is spread
+# across many files, the size is bumped up by ONE bucket (never more) — a wide
+# PR is a bit harder to review, but a mechanical rename across many files is
+# not automatically "huge". Lines lead; files nudge. Both ignore the generated
+# / lock files under `exclude`. Tune everything here; the workflow needs no edits.
+
+# Files whose changes do NOT count toward the size.
+# Shell-style globs where `*` also spans `/` (e.g. `*pnpm-lock.yaml` matches any path).
+exclude:
+  - "*package-lock.json"
+  - "*pnpm-lock.yaml"
+  - "*yarn.lock"
+  - "*uv.lock"
+  - "*.snap"
+  - "*.svg"
+  - "*.received.*"
+  - "*.verified.*"
+
+# Base size from changed lines (additions + deletions). Value = lower bound.
+# Anchored to code-review research: defect detection degrades past ~200 lines,
+# and ~400 lines is the practical ceiling for one effective review.
+lines:
+  XS: 0      # 0–9
+  S: 10      # 10–49
+  M: 50      # 50–199
+  L: 200     # 200–399
+  XL: 400    # 400+
+
+# File spread. If the file-count bucket is higher than the line bucket, the
+# size is bumped up one level. Value = lower bound (XS = 0–1 file).
+files:
+  XS: 0      # 0–1
+  S: 2       # 2–4
+  M: 5       # 5–9
+  L: 10      # 10–24
+  XL: 25     # 25+

--- a/.github/workflows/labeler/stack.yml
+++ b/.github/workflows/labeler/stack.yml
@@ -11,6 +11,7 @@ dotnet:
       - any-glob-to-any-file:
           - "**/*.cs"
           - "**/*.csproj"
+          - "**/*.sln"
           - "**/*.slnx"
           - "**/*.props"
           - "global.json"

--- a/.github/workflows/labeler/stack.yml
+++ b/.github/workflows/labeler/stack.yml
@@ -1,0 +1,99 @@
+# Stack / area labels applied automatically from the files a PR touches.
+# Consumed by actions/labeler@v5 (see .github/workflows/pr-labeler.yml).
+# Patterns are name-agnostic: they match by structure, not by the product
+# folder name, so they keep working after the template is renamed.
+#
+# Polyglot monorepo: .NET (C#), Python, TypeScript (React frontend + AWS CDK
+# IaC), shell / PowerShell scripts, Docker, and cross-cutting build tooling.
+
+dotnet:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.cs"
+          - "**/*.csproj"
+          - "**/*.slnx"
+          - "**/*.props"
+          - "global.json"
+
+react:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/apps/frontend/**"
+
+iac:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/src/iac/**"
+
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.py"
+          - "pyproject.toml"
+          - "uv.lock"
+
+shell:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.sh"
+          - "**/*.ps1"
+          - "**/*.psm1"
+          - "scripts/**"
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Dockerfile"
+          - "**/Dockerfile.*"
+          - "**/*.dcproj"
+          - "**/docker-compose*.yml"
+          - "**/.dockerignore"
+
+npm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/package.json"
+          - "**/pnpm-lock.yaml"
+          - "pnpm-workspace.yaml"
+
+e2e:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/test/e2e/**"
+
+github-actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Makefile"
+          - "biome.json"
+          - "tsconfig.json"
+          - "lefthook.yml"
+          - ".editorconfig"
+          - ".nvmrc"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/skills/**"
+
+ai-workspace:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/ai-process*/**"
+          - "docs/ai-workflows.md"
+
+shared:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "shared/**"

--- a/.github/workflows/labeler/stack.yml
+++ b/.github/workflows/labeler/stack.yml
@@ -59,6 +59,7 @@ npm:
 e2e:
   - changed-files:
       - any-glob-to-any-file:
+          - "e2e/**"
           - "**/test/e2e/**"
 
 github-actions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,201 @@
+name: 🏷️ PR Labeler
+
+# Three-layer auto-labeling, re-evaluated on every push and title/body edit:
+#   1. Stack labels from the files a PR touches (actions/labeler + labeler/stack.yml)
+#   2. Type labels from the Conventional Commit type in the PR title (feat -> enhancement, ...)
+#   3. Size label from the changed-line count (labeler/size.yml)
+# Layers 2 and 3 are mutating: stale labels are removed when the title or diff changes.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  label-by-stack:
+    name: Label by stack (changed files)
+    runs-on: ubuntu-latest
+    # Fork PRs get a read-only GITHUB_TOKEN on pull_request, so label mutations
+    # fail. Skip them: labeling only runs for PRs from branches in this repo.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: 🏷️ Apply stack labels
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/workflows/labeler/stack.yml
+          sync-labels: true
+
+  label-by-type:
+    name: Label by commit type
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: 🏷️ Reconcile Conventional Commit type labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Title-owned type labels this job reconciles on every run.
+          # 'documentation' is intentionally excluded: it is owned by the stack
+          # labeler (any *.md change), so the two jobs never fight over it.
+          managed=(enhancement bug style refactor test chore)
+
+          # Type = text before the first '(', ':' or '!'
+          type="$(printf '%s' "$PR_TITLE" | sed -E 's/[(:!].*$//' | tr -d '[:space:]')"
+          declare -A type_to_label=(
+            [feat]=enhancement
+            [fix]=bug
+            [style]=style
+            [refactor]=refactor
+            [test]=test
+            [chore]=chore
+          )
+          desired="${type_to_label[$type]:-}"
+
+          # Breaking change per Conventional Commits: a '!' before the ':' in the
+          # title, OR a real footer line 'BREAKING CHANGE:' / 'BREAKING-CHANGE:'
+          # (uppercase, start of line, with colon) — not the phrase in prose.
+          breaking=false
+          if printf '%s' "$PR_TITLE" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            breaking=true
+          elif printf '%s' "$PR_BODY" | grep -qE '^BREAKING[ -]CHANGE:'; then
+            breaking=true
+          fi
+
+          mapfile -t current < <(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+          has() { local x; for x in "${current[@]}"; do [[ "$x" == "$1" ]] && return 0; done; return 1; }
+
+          args=()
+          for l in "${managed[@]}"; do
+            if [[ "$l" == "$desired" ]]; then
+              has "$l" || args+=(--add-label "$l")
+            else
+              has "$l" && args+=(--remove-label "$l")
+            fi
+          done
+
+          if [[ "$breaking" == true ]]; then
+            has "breaking-change" || args+=(--add-label "breaking-change")
+          else
+            has "breaking-change" && args+=(--remove-label "breaking-change")
+          fi
+
+          if [[ ${#args[@]} -eq 0 ]]; then
+            echo "Type labels in sync (type='${type}', desired='${desired:-none}', breaking=${breaking})"
+            exit 0
+          fi
+
+          echo "Reconciling type labels: ${args[*]}"
+          gh pr edit "$PR_NUMBER" "${args[@]}"
+
+  label-by-size:
+    name: Label by PR size
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: 🏷️ Compute size and apply label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Read size.yml from the BASE ref (immutable — a PR cannot lower its
+          # own thresholds). Fall back to the PR head only when the file is not
+          # on base yet (the bootstrap PR that introduces size.yml).
+          cfg_path=".github/workflows/labeler/size.yml"
+          fetch_cfg() {
+            gh api "repos/${GH_REPO}/contents/${cfg_path}?ref=$1" \
+              --jq '.content' 2>/dev/null | base64 -d
+          }
+          raw="$(fetch_cfg "$BASE_SHA" || true)"
+          if [[ -z "$raw" ]]; then
+            raw="$(fetch_cfg "$HEAD_SHA" || true)"
+          fi
+          if [[ -z "$raw" ]]; then
+            echo "Could not read ${cfg_path} from base or head; skipping size label."
+            exit 0
+          fi
+
+          # Normalize config to JSON once, then drive everything with jq.
+          # yq ships preinstalled on GitHub-hosted ubuntu-latest runners.
+          json="$(yq -o=json '.' <<< "$raw")"
+
+          mapfile -t excludes < <(jq -r '.exclude[]?' <<< "$json")
+
+          lines=0
+          files=0
+          while IFS=$'\t' read -r path adds dels; do
+            skip=false
+            for pat in "${excludes[@]}"; do
+              case "$path" in
+                $pat) skip=true; break ;;
+              esac
+            done
+            [[ "$skip" == true ]] && continue
+            lines=$(( lines + adds + dels ))
+            files=$(( files + 1 ))
+          done < <(gh pr view "$PR_NUMBER" --json files \
+                     --jq '.files[] | [.path, .additions, .deletions] | @tsv')
+
+          # Ordered bucket names (XS..XL); both dimensions share the same names.
+          mapfile -t names < <(jq -r '.lines | to_entries | sort_by(.value) | .[].key' <<< "$json")
+          maxrank=$(( ${#names[@]} - 1 ))
+
+          # rank_for <value> <dimension> -> bucket index (0 = XS .. maxrank = XL)
+          rank_for() {
+            local value="$1" dim="$2" rank=0 i=0
+            while IFS=$'\t' read -r _ bmin; do
+              if (( value >= bmin )); then rank="$i"; fi
+              i=$(( i + 1 ))
+            done < <(jq -r --arg d "$dim" \
+                       '.[$d] | to_entries | sort_by(.value) | .[] | [.key, (.value | tostring)] | @tsv' <<< "$json")
+            printf '%s' "$rank"
+          }
+
+          lrank="$(rank_for "$lines" lines)"
+          frank="$(rank_for "$files" files)"
+
+          # Lines set the base size; a wider file spread bumps it up ONE level.
+          final="$lrank"
+          if (( frank > lrank )); then
+            final=$(( lrank + 1 ))
+          fi
+          if (( final > maxrank )); then
+            final="$maxrank"
+          fi
+
+          label="size/${names[$final]}"
+          echo "lines=${lines} (${names[$lrank]}), files=${files} (${names[$frank]}) -> ${label}"
+
+          # Remove any stale size/* labels, then apply the current one.
+          while read -r current; do
+            [[ -z "$current" ]] && continue
+            if [[ "$current" != "$label" ]]; then
+              gh pr edit "$PR_NUMBER" --remove-label "$current"
+            fi
+          done < <(gh pr view "$PR_NUMBER" --json labels \
+                     --jq '.labels[].name | select(startswith("size/"))')
+
+          gh pr edit "$PR_NUMBER" --add-label "$label"


### PR DESCRIPTION
## Description

Adds an automated PR labeler so every pull request is tagged consistently by **stack**, **Conventional Commit type**, and **size** — no manual labeling. All three layers run as parallel jobs and re-evaluate on every push and on title/body edits, removing stale labels as the PR changes. The canonical label set has already been added to this repo.

## Changes Made

- New workflow `.github/workflows/pr-labeler.yml` with three parallel jobs:
  - **Stack** — `actions/labeler@v5` driven by `labeler/stack.yml`, `sync-labels: true`. Name-agnostic globs cover python, npm, dotnet, shell, docker, github-actions, build, documentation, e2e, … (fits the Envilder CLI + GitHub Action + SDK layout).
  - **Type** — maps the Conventional Commit type in the PR title to a label (`feat`→`enhancement`, `fix`→`bug`, `refactor`, `test`, `style`, `chore`) and adds `breaking-change` on a title `!` or a real `BREAKING CHANGE:` footer. Mutating.
  - **Size** — `size/XS…XL` from changed lines (base) bumped one level by a wide file spread. Thresholds and excludes in `labeler/size.yml`.

## Notes

- PR title/body are passed via env vars (never interpolated into the shell) to avoid script injection.
- Fork PRs are skipped (read-only token).
- A few stack labels (iac, react, shared, ai-workspace) won't match this repo's layout; they are harmless.
