### PR TITLE
docs: ADR-0010 actionable errors and CLI error presentation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,3 +35,11 @@ these terms consistently to avoid drift.
 | **Lowkey Vault** | Local Azure Key Vault emulator for acceptance tests. Runs in Docker via TestContainers. |
 | **Container wrapper** | Test helper class with explicit `start()`/`stop()` lifecycle managing a TestContainer instance. |
 | **Conformance fixture** | Shared test data (input map + expected output) validating SDK behavior across languages. |
+
+## Output & Errors
+
+| Term | Definition |
+|------|-----------|
+| **CLI output** | Proactive, human-facing console messages (info, success, progress) shown to an interactive terminal user. CLI-only. SDKs never emit it — they stay silent-by-default. |
+| **Error message** | The human-readable text carried by a thrown error/exception. Emitted by both the CLI and every SDK. Must be clear and actionable. This is the only channel through which SDKs participate in messaging. |
+| **SSO session expired** | Condition where the AWS SSO / IAM Identity Center cached token is missing or expired (the user never ran `aws sso login`, or it lapsed). Modeled as a dedicated typed error (`SsoSessionExpiredError`) in the CLI core and each SDK, carrying a standard, actionable message. |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,5 +41,5 @@ these terms consistently to avoid drift.
 | Term | Definition |
 |------|-----------|
 | **CLI output** | Proactive, human-facing console messages (info, success, progress) shown to an interactive terminal user. CLI-only. SDKs never emit it — they stay silent-by-default. |
-| **Error message** | The human-readable text carried by a thrown error/exception. Emitted by both the CLI and every SDK. Must be clear and actionable. This is the only channel through which SDKs participate in messaging. |
-| **SSO session expired** | Condition where the AWS SSO / IAM Identity Center cached token is missing or expired (the user never ran `aws sso login`, or it lapsed). Modeled as a dedicated typed error (`SsoSessionExpiredError`) in the CLI core and each SDK, carrying a standard, actionable message. |
+| **Error message** | The human-readable text carried by a thrown error/exception. Produced by both the CLI and every SDK. Must be clear and actionable. This is the only channel through which SDKs participate in messaging. |
+| **SSO session expired** | Condition where the AWS SSO / IAM Identity Center cached token is missing or expired (the user never ran `aws sso login`, or it lapsed). Per ADR-0010, this is to be modeled as a dedicated typed error (`SsoSessionExpiredError`) in the CLI core and each SDK, carrying a standard, actionable message. *(Planned — not yet implemented.)* |

--- a/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
+++ b/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
@@ -62,10 +62,10 @@ What is "unified" is the *contract*, not the code: identical error types,
 identical structured data, and identical default-message wording across the CLI
 and every SDK. The rich, interactive presentation is exclusive to the CLI.
 
-### 5. Message quality bar
+### 5. Message standards
 
 Every error message and remediation — CLI output and SDK error text alike — must
-clear this bar:
+meet these standards:
 
 - **Plain and direct.** Written for a broad developer audience; no internal
   jargon, no provider stack-trace noise leaking through. A reader should

--- a/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
+++ b/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
@@ -62,6 +62,26 @@ What is "unified" is the *contract*, not the code: identical error types,
 identical structured data, and identical default-message wording across the CLI
 and every SDK. The rich, interactive presentation is exclusive to the CLI.
 
+### 5. Message quality bar
+
+Every error message and remediation — CLI output and SDK error text alike — must
+clear this bar:
+
+- **Plain and direct.** Written for a broad developer audience; no internal
+  jargon, no provider stack-trace noise leaking through. A reader should
+  understand what went wrong without prior Envilder knowledge.
+- **Actionable, step-by-step.** State the problem in one line, then the exact
+  steps to fix it (e.g. *"Run `aws sso login --profile dev`, then retry"*).
+  Never just report a failure without a path forward.
+- **Professional and calm.** No blame, no cute noise in the *failure* path
+  (the playful tone in the success path stays; errors are reassuring and
+  precise).
+- **Keyword-anchored.** Surface the concrete nouns that let a user search/act:
+  the profile name, the command to run, the provider.
+- **CLI = aesthetically formatted** (colour, icon, layout, indentation) via the
+  `CliErrorPresenter`. **SDK = clean plain text** in the thrown error — no ANSI
+  colour (it may land in logs/JSON), but the same clarity and steps.
+
 ## Consequences
 
 - **More public API surface per stack** — each runtime gains new public error

--- a/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
+++ b/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
@@ -1,0 +1,97 @@
+# ADR-0010: Actionable Errors and Centralized CLI Error Presentation
+
+## Status
+
+Accepted
+
+## Context
+
+Error handling in Envilder is currently coarse. Infrastructure adapters wrap
+almost every non-`ParameterNotFound` failure into a generic
+`SecretOperationError` carrying a raw provider message. When an AWS SSO / IAM
+Identity Center session is missing or expired (the user never ran
+`aws sso login`, or the cached token lapsed), the CLI surfaces a cryptic message
+and exits — giving no guidance on how to recover. The SSO fix in #364 made valid
+profiles resolve correctly, but the *failure* path remains unfriendly.
+
+Two constraints shape the solution:
+
+1. **SDKs are silent-by-default** (architecture) and run in non-interactive
+   contexts (CI, containers, app startup). They participate in messaging *only*
+   through the text of the errors they throw — never proactive console output.
+2. **SDKs are independent** (ADR-0003) — there is no shared code across the CLI
+   core and the runtime SDKs. Any "unification" can only be a shared *convention*
+   (error types, structured data, default wording), not a shared library.
+
+A distinct, interactive consumer exists — the CLI — where richer presentation
+(colors, layout, a profile-loaded confirmation, and an optional
+`aws sso login` redirect) is appropriate.
+
+## Decision
+
+### 1. Typed, data-carrying domain errors
+
+Actionable failure conditions are modeled as typed errors extending the existing
+`DomainError` base. Each carries **structured data** plus a sensible **default
+message** built in its constructor — exactly the pattern already used by
+`ParameterNotFoundError` (which carries `paramName`).
+
+The first instance is `SsoSessionExpiredError`, carrying the `profileName`. This
+lets the CLI react by **type** (robust) instead of string-matching provider
+messages, and lets SDK consumers `catch` it programmatically.
+
+### 2. Single CLI error-presentation point
+
+The CLI's lone catch site (`apps/cli/Index.ts` `main().catch(...)`) is refactored
+into a dedicated `CliErrorPresenter`. This is the **one place** that maps an
+error type to its interactive rendering: icon, colour, layout, remediation hint,
+and — for `SsoSessionExpiredError` — the optional `aws sso login` redirect.
+Centralizing here means the CLI's wording and styling are restyled in one spot,
+not scattered per error.
+
+### 3. SDKs replicate the pattern, not the presentation
+
+Each SDK defines the equivalent typed errors (same names, same structured data,
+same default message wording) so a caught error is self-describing. SDKs do
+**not** ship the rich presenter and stay silent-by-default. Their participation
+in messaging is the thrown error's default message only.
+
+### 4. The cross-stack convention
+
+What is "unified" is the *contract*, not the code: identical error types,
+identical structured data, and identical default-message wording across the CLI
+and every SDK. The rich, interactive presentation is exclusive to the CLI.
+
+## Consequences
+
+- **More public API surface per stack** — each runtime gains new public error
+  types. This is a breaking-by-addition contract that is hard to reverse, which
+  is why it is recorded here.
+- **Per-stack SSO detection** — each adapter must recognize its native SSO
+  failure (AWS SDK v3 token error, boto3 `UnauthorizedSSOTokenError` /
+  `SSOTokenLoadError`, .NET SSO token resolution) and translate it to the shared
+  typed error.
+- **Redirect must be guarded** — the `aws sso login` redirect is CLI-only,
+  TTY-gated (never spawned in CI / non-interactive shells), and prompts before
+  launching. It is never part of any SDK.
+- **Profile-loaded confirmation** is CLI-only output, must not leak secret
+  values, and reports only non-sensitive context (profile name, region).
+
+## Sibling case: Azure
+
+The same actionable-error shape applies to Azure, where `DefaultAzureCredential`
+fails when no credential in its chain is usable (e.g. the user never ran
+`az login`, or the Entra ID token lapsed). The remediation is `az login`.
+
+Two differences make Azure fuzzier and keep it out of the initial scope:
+
+1. `DefaultAzureCredential` is a **chain**, so a failure means "no credential
+   worked", not "this profile's token expired" — the remediation is less
+   deterministic (could be `az login`, service-principal env vars, or managed
+   identity).
+2. Azure has **no profile concept** (tenants/subscriptions instead), so an
+   `AzureLoginRequiredError` would carry the vault URL, not a profile name.
+
+The base pattern is provider-agnostic by design. The AWS case is implemented
+first (scope of #364); the Azure sibling (`AzureLoginRequiredError` →
+`az login`) is a tracked follow-up.

--- a/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
+++ b/docs/adr/0010-actionable-errors-and-cli-error-presentation.md
@@ -42,9 +42,9 @@ messages, and lets SDK consumers `catch` it programmatically.
 
 ### 2. Single CLI error-presentation point
 
-The CLI's lone catch site (`apps/cli/Index.ts` `main().catch(...)`) is refactored
+The CLI's lone catch site (`src/envilder/apps/cli/Index.ts` `main().catch(...)`) is refactored
 into a dedicated `CliErrorPresenter`. This is the **one place** that maps an
-error type to its interactive rendering: icon, colour, layout, remediation hint,
+error type to its interactive rendering: icon, color, layout, remediation hint,
 and — for `SsoSessionExpiredError` — the optional `aws sso login` redirect.
 Centralizing here means the CLI's wording and styling are restyled in one spot,
 not scattered per error.
@@ -78,9 +78,9 @@ meet these standards:
   precise).
 - **Keyword-anchored.** Surface the concrete nouns that let a user search/act:
   the profile name, the command to run, the provider.
-- **CLI = aesthetically formatted** (colour, icon, layout, indentation) via the
+- **CLI = aesthetically formatted** (color, icon, layout, indentation) via the
   `CliErrorPresenter`. **SDK = clean plain text** in the thrown error — no ANSI
-  colour (it may land in logs/JSON), but the same clarity and steps.
+  color (it may land in logs/JSON), but the same clarity and steps.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

Adds **ADR-0010** capturing the design for actionable errors and centralized CLI
error presentation, elaborated in a grilling session.

The trigger: when an AWS SSO / assumed-role profile is selected but the user
hasn't run `aws sso login` (or the token expired), Envilder fails with a cryptic
message and no guidance. This ADR records the model for fixing that class of
failure across the CLI and SDKs.

## Decision (in the ADR)

- **Typed, data-carrying domain errors** extending `DomainError` (e.g.
  `SsoSessionExpiredError` with `profileName`), following the existing
  `ParameterNotFoundError` pattern.
- **A single CLI error-presentation point** (`CliErrorPresenter`, refactor of the
  `Index.ts` catch) that maps error type → aesthetic message + remediation +
  optional `aws sso login` redirect (TTY-gated).
- **SDKs replicate the pattern, not the presentation** — same error types, data,
  and default wording; silent-by-default; messaging only via thrown error text.
- **Cross-stack convention, not shared code** (ADR-0003): the contract is
  unified, the implementation is per-stack.
- **Azure sibling case** noted (`az login` / `DefaultAzureCredential`), tracked
  as a follow-up.

## Also

- Adds glossary terms to `CONTEXT.md`: **CLI output**, **Error message**,
  **SSO session expired**.

## Follow-up issues

Implementation is decomposed into separate vertical-slice issues (typed error +
detection, `CliErrorPresenter`, SSO redirect, profile-loaded message, SDK
replication, Azure sibling) — linked once opened.

No behavioral code changes in this PR — documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record for consistent, actionable CLI error messaging.
  * Defined structured, typed error details (including expired SSO session context) with safe, non-sensitive output.
  * Documented interactive remediation flows for expired SSO sessions (TTY-gated redirect to `aws sso login`) and shared cross-stack error conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->