### PR TITLE
ci(dependabot): group updates and auto-merge minor/patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,21 +4,37 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
-updates: 
+updates:
 - package-ecosystem: npm
   directory: "/"
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "@aws-sdk/*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "npm"
   - "dependencies"
   assignees:
   - macalbert
-    
+
 - package-ecosystem: nuget
   directories:
   - "/src/sdks/dotnet"
@@ -26,9 +42,28 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "AWSSDK.*"
+    azure-sdk:
+      patterns:
+      - "Azure.*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "nuget"
   - "dependencies"
@@ -42,9 +77,28 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "github.com/aws/aws-sdk-go-v2*"
+    azure-sdk:
+      patterns:
+      - "github.com/Azure/*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "go"
   - "dependencies"
@@ -58,9 +112,28 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "software.amazon.awssdk:*"
+    azure-sdk:
+      patterns:
+      - "com.azure:*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "maven"
   - "dependencies"
@@ -74,9 +147,29 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "boto3"
+      - "botocore"
+    azure-sdk:
+      patterns:
+      - "azure-*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "pip"
   - "dependencies"
@@ -90,9 +183,28 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    aws-sdk:
+      patterns:
+      - "@aws-sdk/*"
+    azure-sdk:
+      patterns:
+      - "@azure/*"
+    dev-minor-patch:
+      dependency-type: development
+      update-types:
+      - minor
+      - patch
+    prod-minor-patch:
+      dependency-type: production
+      update-types:
+      - minor
+      - patch
   labels:
   - "npm"
   - "dependencies"
@@ -104,9 +216,16 @@ updates:
   pull-request-branch-name:
     separator: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
     time: "10:00"
     timezone: Europe/Madrid
+  open-pull-requests-limit: 5
+  groups:
+    actions-minor-patch:
+      update-types:
+      - minor
+      - patch
   labels:
   - "github-actions"
   - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     aws-sdk:
       patterns:
       - "@aws-sdk/*"
+      update-types:
+      - minor
+      - patch
+    azure-sdk:
+      patterns:
+      - "@azure/*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:
@@ -51,9 +60,15 @@ updates:
     aws-sdk:
       patterns:
       - "AWSSDK.*"
+      update-types:
+      - minor
+      - patch
     azure-sdk:
       patterns:
       - "Azure.*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:
@@ -86,9 +101,15 @@ updates:
     aws-sdk:
       patterns:
       - "github.com/aws/aws-sdk-go-v2*"
+      update-types:
+      - minor
+      - patch
     azure-sdk:
       patterns:
       - "github.com/Azure/*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:
@@ -121,9 +142,15 @@ updates:
     aws-sdk:
       patterns:
       - "software.amazon.awssdk:*"
+      update-types:
+      - minor
+      - patch
     azure-sdk:
       patterns:
       - "com.azure:*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:
@@ -157,9 +184,15 @@ updates:
       patterns:
       - "boto3"
       - "botocore"
+      update-types:
+      - minor
+      - patch
     azure-sdk:
       patterns:
       - "azure-*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:
@@ -192,9 +225,15 @@ updates:
     aws-sdk:
       patterns:
       - "@aws-sdk/*"
+      update-types:
+      - minor
+      - patch
     azure-sdk:
       patterns:
       - "@azure/*"
+      update-types:
+      - minor
+      - patch
     dev-minor-patch:
       dependency-type: development
       update-types:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,12 +2,28 @@ name: ⭐ Dependabot Auto-merge
 
 # Auto-merges Dependabot PRs once required checks are green, but only for
 # minor/patch bumps. Major version bumps are left open for manual review.
+#
+# Uses pull_request_target instead of pull_request: workflows triggered by
+# Dependabot via pull_request always get a read-only GITHUB_TOKEN regardless
+# of the permissions block, which would make `gh pr merge --auto` fail with
+# a permission error. pull_request_target grants the requested write
+# permissions instead. This is safe here because the job never checks out
+# or executes any code from the PR head.
+#
+# Gated on the PR author (not github.actor) so a maintainer clicking
+# "Update branch" (which re-triggers synchronize as its own actor) doesn't
+# skip this job on a Dependabot PR.
+#
+# go_modules and maven are excluded: there is no CI workflow for the Go or
+# Java SDKs yet, so no required status check would ever gate those PRs and
+# `--auto` would merge them without waiting for any test run.
+#
 # Requires "Allow auto-merge" enabled in repo settings and branch protection
 # with required status checks on main, otherwise this would merge without
 # waiting for CI.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -25,7 +41,10 @@ jobs:
   automerge:
     name: Auto-merge minor/patch
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/') &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/maven/')
     steps:
       - name: 📋 Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,41 @@
+name: ⭐ Dependabot Auto-merge
+
+# Auto-merges Dependabot PRs once required checks are green, but only for
+# minor/patch bumps. Major version bumps are left open for manual review.
+# Requires "Allow auto-merge" enabled in repo settings and branch protection
+# with required status checks on main, otherwise this would merge without
+# waiting for CI.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    name: Auto-merge minor/patch
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: 📋 Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: ✅ Enable auto-merge
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/tests-dotnet-sdk.yml
+++ b/.github/workflows/tests-dotnet-sdk.yml
@@ -15,19 +15,37 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - '.github/workflows/tests-dotnet-sdk.yml'
-      - 'src/sdks/dotnet/**'
-      - 'tests/sdks/dotnet/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  test-dotnet-sdk:
+  # No `paths:` filter here on purpose: a required check gated by a
+  # workflow-level `paths:` filter never posts a status when skipped and
+  # blocks merging forever. A job-level `if:` skip reports "success"
+  # instead, so the path check moves here and gates test-dotnet-sdk below.
+  changes:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+    steps:
+      - name: 🧱 Checkout
+        uses: actions/checkout@v7
+      - name: 🔍 Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - '.github/workflows/tests-dotnet-sdk.yml'
+              - 'src/sdks/dotnet/**'
+              - 'tests/sdks/dotnet/**'
+
+  test-dotnet-sdk:
+    needs: changes
+    runs-on: ubuntu-24.04
+    if: ${{ needs.changes.outputs.dotnet == 'true' && !github.event.pull_request.draft }}
     timeout-minutes: 10
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/tests-dotnet-sdk.yml
+++ b/.github/workflows/tests-dotnet-sdk.yml
@@ -27,12 +27,16 @@ jobs:
   # instead, so the path check moves here and gates test-dotnet-sdk below.
   changes:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       dotnet: ${{ steps.filter.outputs.dotnet }}
     steps:
       - name: 🧱 Checkout
         uses: actions/checkout@v7
       - name: 🔍 Detect relevant changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -45,7 +49,7 @@ jobs:
   test-dotnet-sdk:
     needs: changes
     runs-on: ubuntu-24.04
-    if: ${{ needs.changes.outputs.dotnet == 'true' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (needs.changes.outputs.dotnet == 'true' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/tests-nodejs-sdk.yml
+++ b/.github/workflows/tests-nodejs-sdk.yml
@@ -16,19 +16,37 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - '.github/workflows/tests-nodejs-sdk.yml'
-      - 'src/sdks/nodejs/**'
-      - 'tests/sdks/nodejs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  test-nodejs-sdk:
+  # No `paths:` filter here on purpose: a required check gated by a
+  # workflow-level `paths:` filter never posts a status when skipped and
+  # blocks merging forever. A job-level `if:` skip reports "success"
+  # instead, so the path check moves here and gates test-nodejs-sdk below.
+  changes:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      nodejs: ${{ steps.filter.outputs.nodejs }}
+    steps:
+      - name: 🧱 Checkout
+        uses: actions/checkout@v7
+      - name: 🔍 Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            nodejs:
+              - '.github/workflows/tests-nodejs-sdk.yml'
+              - 'src/sdks/nodejs/**'
+              - 'tests/sdks/nodejs/**'
+
+  test-nodejs-sdk:
+    needs: changes
+    runs-on: ubuntu-24.04
+    if: ${{ needs.changes.outputs.nodejs == 'true' && !github.event.pull_request.draft }}
     timeout-minutes: 10
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/tests-nodejs-sdk.yml
+++ b/.github/workflows/tests-nodejs-sdk.yml
@@ -28,12 +28,16 @@ jobs:
   # instead, so the path check moves here and gates test-nodejs-sdk below.
   changes:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       nodejs: ${{ steps.filter.outputs.nodejs }}
     steps:
       - name: 🧱 Checkout
         uses: actions/checkout@v7
       - name: 🔍 Detect relevant changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -46,7 +50,7 @@ jobs:
   test-nodejs-sdk:
     needs: changes
     runs-on: ubuntu-24.04
-    if: ${{ needs.changes.outputs.nodejs == 'true' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (needs.changes.outputs.nodejs == 'true' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/tests-python-sdk.yml
+++ b/.github/workflows/tests-python-sdk.yml
@@ -27,12 +27,16 @@ jobs:
   # instead, so the path check moves here and gates test-python-sdk below.
   changes:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       python: ${{ steps.filter.outputs.python }}
     steps:
       - name: 🧱 Checkout
         uses: actions/checkout@v7
       - name: 🔍 Detect relevant changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -45,7 +49,7 @@ jobs:
   test-python-sdk:
     needs: changes
     runs-on: ubuntu-24.04
-    if: ${{ needs.changes.outputs.python == 'true' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (needs.changes.outputs.python == 'true' && !github.event.pull_request.draft) }}
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/tests-python-sdk.yml
+++ b/.github/workflows/tests-python-sdk.yml
@@ -15,19 +15,37 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - '.github/workflows/tests-python-sdk.yml'
-      - 'src/sdks/python/**'
-      - 'tests/sdks/python/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  test-python-sdk:
+  # No `paths:` filter here on purpose: a required check gated by a
+  # workflow-level `paths:` filter never posts a status when skipped and
+  # blocks merging forever. A job-level `if:` skip reports "success"
+  # instead, so the path check moves here and gates test-python-sdk below.
+  changes:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - name: 🧱 Checkout
+        uses: actions/checkout@v7
+      - name: 🔍 Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - '.github/workflows/tests-python-sdk.yml'
+              - 'src/sdks/python/**'
+              - 'tests/sdks/python/**'
+
+  test-python-sdk:
+    needs: changes
+    runs-on: ubuntu-24.04
+    if: ${{ needs.changes.outputs.python == 'true' && !github.event.pull_request.draft }}
     timeout-minutes: 10
 
     strategy:

--- a/.github/workflows/tests-website.yml
+++ b/.github/workflows/tests-website.yml
@@ -11,22 +11,40 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - ".github/workflows/tests-website.yml"
-      - "src/website/**"
-      - "tests/website/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  website-ci:
+  # No `paths:` filter here on purpose: a required check gated by a
+  # workflow-level `paths:` filter never posts a status when skipped and
+  # blocks merging forever. A job-level `if:` skip reports "success"
+  # instead, so the path check moves here and gates website-ci below.
+  changes:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      website: ${{ steps.filter.outputs.website }}
+    steps:
+      - name: 🧱 Checkout
+        uses: actions/checkout@v7
+      - name: 🔍 Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            website:
+              - ".github/workflows/tests-website.yml"
+              - "src/website/**"
+              - "tests/website/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+
+  website-ci:
+    needs: changes
+    runs-on: ubuntu-24.04
+    if: ${{ needs.changes.outputs.website == 'true' && !github.event.pull_request.draft }}
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/tests-website.yml
+++ b/.github/workflows/tests-website.yml
@@ -23,6 +23,9 @@ jobs:
   # instead, so the path check moves here and gates website-ci below.
   changes:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       website: ${{ steps.filter.outputs.website }}
     steps:

--- a/.github/workflows/tests-website.yml
+++ b/.github/workflows/tests-website.yml
@@ -29,6 +29,7 @@ jobs:
       - name: 🧱 Checkout
         uses: actions/checkout@v7
       - name: 🔍 Detect relevant changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -44,7 +45,7 @@ jobs:
   website-ci:
     needs: changes
     runs-on: ubuntu-24.04
-    if: ${{ needs.changes.outputs.website == 'true' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (needs.changes.outputs.website == 'true' && !github.event.pull_request.draft) }}
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
       - name: 🧱 Checkout
         uses: actions/checkout@v7
       - name: 🔍 Detect relevant changes
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -53,7 +54,7 @@ jobs:
   powerup-test:
     needs: changes
     runs-on: ubuntu-24.04
-    if: ${{ needs.changes.outputs.core == 'true' && !github.event.pull_request.draft }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (needs.changes.outputs.core == 'true' && !github.event.pull_request.draft) }}
     timeout-minutes: 30
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,25 +17,43 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    paths:
-      - ".github/workflows/tests.yml"
-      - "github-action/action.yml"
-      - "src/envilder/**"
-      - "tests/envilder/**"
-      - "e2e/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "tsconfig.json"
-      - "vite.config.ts"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  powerup-test:
+  # No `paths:` filter here on purpose: a required check gated by a
+  # workflow-level `paths:` filter never posts a status when skipped and
+  # blocks merging forever. A job-level `if:` skip reports "success"
+  # instead, so the path check moves here and gates powerup-test below.
+  changes:
     runs-on: ubuntu-24.04
-    if: ${{ !github.event.pull_request.draft }}
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - name: 🧱 Checkout
+        uses: actions/checkout@v7
+      - name: 🔍 Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - ".github/workflows/tests.yml"
+              - "github-action/action.yml"
+              - "src/envilder/**"
+              - "tests/envilder/**"
+              - "e2e/**"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "tsconfig.json"
+              - "vite.config.ts"
+
+  powerup-test:
+    needs: changes
+    runs-on: ubuntu-24.04
+    if: ${{ needs.changes.outputs.core == 'true' && !github.event.pull_request.draft }}
     timeout-minutes: 30
     env:
       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Reduces Dependabot PR noise and lockfile/format conflicts caused by many
small updates sitting open at once, and makes CI safe to require for
auto-merge:

- `.github/dependabot.yml`: adds `groups:` (`aws-sdk`/`azure-sdk`, each
  scoped to `update-types: [minor, patch]` so major bumps stay
  ungrouped, + `dev-minor-patch`/`prod-minor-patch`) to every ecosystem
  block (npm root, npm Node.js SDK, nuget, gomod, maven, pip,
  github-actions), switches `schedule.interval` from `daily` to
  `weekly` (Monday), and adds `open-pull-requests-limit: 5`.
- `.github/workflows/dependabot-automerge.yml` (new): enables GitHub
  auto-merge (squash) on Dependabot PRs via `dependabot/fetch-metadata@v2`,
  gated on `update-type != version-update:semver-major`. Uses
  `pull_request_target` (Dependabot PRs get a read-only `GITHUB_TOKEN`
  on plain `pull_request`) and gates on the PR author, not `github.actor`.
  Excludes `dependabot/go_modules/` and `dependabot/maven/` branches:
  there is no CI workflow for the Go or Java SDKs yet, so there would be
  nothing to wait for.
- `tests.yml`, `tests-website.yml`, `tests-dotnet-sdk.yml`,
  `tests-nodejs-sdk.yml`, `tests-python-sdk.yml`: moved the `paths:`
  filter out of `on.pull_request` into a new `changes` job
  (`dorny/paths-filter`), with the real test job gated by
  `needs: changes` + a job-level `if:`. A required check gated by a
  workflow-level `paths:` filter never posts a status when skipped and
  blocks merging forever (confirmed in GitHub's own docs); a job-level
  `if:` skip reports "success" instead, so these checks can now be
  safely marked required in branch protection. `workflow_dispatch` runs
  always execute regardless of the path filter.

No dependencies or lockfiles were touched by hand.

## Related issues

N/A

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other (CI/dependency-management config)

## Checklist

- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)
- [x] Lint/format pass (`pnpm lint` and `secretlint` on changed files)

## Notes for reviewer

This PR alone is not enough for auto-merge to be safe. Two manual one-time
repo settings still need to be enabled (checked via `gh api`, currently both
missing):

1. Settings > General > Pull Requests > **Allow auto-merge** (currently
   `allow_auto_merge: false`).
2. Branch protection on `main` with **required status checks**: mark
   `powerup-test`, `test-dotnet-sdk`, `test-nodejs-sdk`,
   `test-python-sdk`, and `website-ci` as required (currently
   `required_status_checks.checks: []`, i.e. none required). These jobs
   are now safe to require because of the `changes`-job refactor above.

Known gap: gomod/maven Dependabot PRs have no CI to require yet
(no Go/Java SDK test workflow exists), so the auto-merge workflow
explicitly excludes those two ecosystems until CI is added for them.
