### PR TITLE
chore(dependabot): add package cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -56,6 +59,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -97,6 +103,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -138,6 +147,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -179,6 +191,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -221,6 +236,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     aws-sdk:
       patterns:
@@ -260,6 +278,9 @@ updates:
     time: "10:00"
     timezone: Europe/Madrid
   open-pull-requests-limit: 5
+  cooldown:
+    default-days: 7
+    semver-major-days: 14
   groups:
     actions-minor-patch:
       update-types:


### PR DESCRIPTION
## Summary

Adds Dependabot cooldown policies to all seven update entries. Defers package updates by seven days and major version updates by fourteen days to reduce update churn.

## Changes

- Adds default and major semantic-version cooldowns to npm, NuGet, Go, Maven, Python, Node.js, and GitHub Actions updates.

## Testing

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm verify:gha` passes
- [x] Manual verification: Dependabot YAML parsed with seven matching cooldown blocks and `git diff --check` passes.

## Related

N/A
