### PR TITLE
fix(dependabot): remove unsupported cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -280,7 +280,6 @@ updates:
   open-pull-requests-limit: 5
   cooldown:
     default-days: 7
-    semver-major-days: 14
   groups:
     actions-minor-patch:
       update-types:


### PR DESCRIPTION
## Summary

Removes a Dependabot cooldown option that GitHub Actions updates do not support.
This lets Dependabot parse the repository configuration and resume processing dependency PRs such as #447.

## Changes

- Retain the seven-day default cooldown for GitHub Actions updates.
- Remove the unsupported `semver-major-days` cooldown setting from the GitHub Actions entry.

## Testing

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` -- unrelated Lowkey Vault container startup timeout
- [ ] `pnpm verify:gha` -- reports a pre-existing stale action bundle outside this change
- [x] `git diff --check` passes
- [ ] Manual verification -- pending Dependabot configuration check on this PR

## Related

#447
