### PR TITLE
chore(dx): serialize Node dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/"
+  directories:
+  - "/"
+  - "/src/sdks/nodejs"
+  - "/tests/sdks/nodejs"
   pull-request-branch-name:
     separator: "/"
   schedule:
@@ -14,30 +17,14 @@ updates:
     day: monday
     time: "10:00"
     timezone: Europe/Madrid
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 1
   cooldown:
     default-days: 7
     semver-major-days: 14
   groups:
-    aws-sdk:
+    node-minor-patch:
       patterns:
-      - "@aws-sdk/*"
-      update-types:
-      - minor
-      - patch
-    azure-sdk:
-      patterns:
-      - "@azure/*"
-      update-types:
-      - minor
-      - patch
-    dev-minor-patch:
-      dependency-type: development
-      update-types:
-      - minor
-      - patch
-    prod-minor-patch:
-      dependency-type: production
+      - "*"
       update-types:
       - minor
       - patch
@@ -220,50 +207,6 @@ updates:
       - patch
   labels:
   - "pip"
-  - "dependencies"
-  assignees:
-  - macalbert
-
-- package-ecosystem: npm
-  directories:
-  - "/src/sdks/nodejs"
-  - "/tests/sdks/nodejs"
-  pull-request-branch-name:
-    separator: "/"
-  schedule:
-    interval: weekly
-    day: monday
-    time: "10:00"
-    timezone: Europe/Madrid
-  open-pull-requests-limit: 5
-  cooldown:
-    default-days: 7
-    semver-major-days: 14
-  groups:
-    aws-sdk:
-      patterns:
-      - "@aws-sdk/*"
-      update-types:
-      - minor
-      - patch
-    azure-sdk:
-      patterns:
-      - "@azure/*"
-      update-types:
-      - minor
-      - patch
-    dev-minor-patch:
-      dependency-type: development
-      update-types:
-      - minor
-      - patch
-    prod-minor-patch:
-      dependency-type: production
-      update-types:
-      - minor
-      - patch
-  labels:
-  - "npm"
   - "dependencies"
   assignees:
   - macalbert

--- a/docs/adr/0012-serialized-node-dependency-updates.md
+++ b/docs/adr/0012-serialized-node-dependency-updates.md
@@ -1,0 +1,60 @@
+# ADR-0012: Serialized Node Dependency Updates
+
+## Status
+
+Accepted
+
+## Context
+
+Envilder is a pnpm workspace with one committed root `pnpm-lock.yaml` shared by
+the root package and the Node.js SDK workspaces. Updating a dependency changes
+both its manifest and the shared lockfile.
+
+The previous Dependabot configuration split Node.js minor and patch updates into
+separate AWS SDK, Azure SDK, development, and production groups. Dependabot
+could therefore open several pull requests concurrently, each editing the same
+lockfile. Merging one pull request regularly made the others conflict, delaying
+routine production changes and creating avoidable manual work.
+
+## Decision
+
+Node.js version updates are configured as one Dependabot `npm` entry covering
+the root package, Node.js SDK, and Node.js SDK tests. It follows these rules:
+
+1. Dependabot opens at most one Node.js version-update pull request at a time.
+2. Minor and patch updates in each manifest are matched by one
+   `node-minor-patch` group.
+3. Major updates are not part of that group, so they remain individually
+   reviewable once the current version-update pull request has merged or closed.
+4. The committed lockfile remains required and is updated by Dependabot.
+5. The existing auto-merge workflow remains responsible for eligible minor and
+   patch pull requests after required CI checks pass.
+
+This policy applies to Dependabot version updates. Security-update handling is
+not changed by this ADR.
+
+## Consequences
+
+### Positive
+
+- No two Node.js version-update pull requests modify the shared lockfile at the
+  same time.
+- Minor and patch maintenance requires fewer reviews and produces fewer merge
+  conflicts.
+- The lockfile continues to provide reproducible dependency resolution.
+- Major upgrades retain explicit review and can be addressed independently.
+
+### Negative
+
+- A failing or deferred Node.js update blocks later version updates until it is
+  resolved or closed.
+- A grouped minor or patch pull request can contain several dependency changes,
+  increasing the scope of one review.
+
+## When to Reconsider
+
+- A Node.js workspace receives its own committed lockfile and no longer shares
+  the root lockfile.
+- A grouped update repeatedly causes failures that are difficult to isolate.
+- A merge queue is introduced and demonstrably removes the lockfile-conflict
+  cost while preserving deployment throughput.


### PR DESCRIPTION
## Summary

Serialize Node.js Dependabot version updates so concurrent pull requests no longer conflict on the shared pnpm lockfile.
Document the maintenance policy and retain automatic merging for eligible minor and patch updates.

## Changes

- Consolidate root, Node.js SDK, and Node.js SDK test updates into one npm Dependabot configuration with one open version-update pull request.
- Group minor and patch updates under `node-minor-patch` while leaving major updates individually reviewable.
- Add ADR-0012 to record the policy, trade-offs, and reconsideration criteria.

## Testing

- [x] `pnpm format` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` -- 10 E2E tests fail because the global `envilder` CLI is unavailable in this Windows environment.
- [x] Manual verification -- parsed the Dependabot configuration and asserted the serialized Node.js update policy.

## Related

Supersedes #458.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architectural decision record documenting the policy for managing Node.js dependency updates.
  * Clarified how minor, patch, and major updates are grouped, reviewed, and merged.
  * Documented lockfile handling, expected benefits, trade-offs, and criteria for revisiting the policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->