### PR TITLE
fix(website): stabilize animated terminal

### DIFF
--- a/src/website/src/components/Hero.astro
+++ b/src/website/src/components/Hero.astro
@@ -34,6 +34,8 @@ const jsonLines: Line[] = [
   { kind: 'output', segments: [{ text: '}', cls: 'output' }] },
 ];
 
+const cliRule = '━'.repeat(60);
+
 const scenes: Scene[] = [
   {
     id: 'setup',
@@ -98,12 +100,33 @@ const scenes: Scene[] = [
           { text: '=/openai/prod/api-key', cls: 'command' },
         ],
       },
+      { kind: 'blank' },
       {
         kind: 'output',
         delay: 450,
+        segments: [{ text: '📤 PUSHING SECRET', cls: 'highlight' }],
+      },
+      {
+        kind: 'output',
+        segments: [{ text: cliRule, cls: 'highlight' }],
+      },
+      {
+        kind: 'output',
         segments: [
+          { text: '  → ', cls: 'output' },
+          { text: 'OPENAI_API_KEY', cls: 'command' },
+          { text: ' → *****************key', cls: 'output' },
+        ],
+      },
+      { kind: 'blank' },
+      {
+        kind: 'output',
+        segments: [
+          { text: '⭐ SECRET PUSHED', cls: 'highlight' },
+          { text: '  —  ', cls: 'output' },
+          { text: 'OPENAI_API_KEY', cls: 'command' },
           {
-            text: 'Pushed OPENAI_API_KEY=************************lu3 to secret store at path *****************key',
+            text: '=************************lu3 → *****************key',
             cls: 'output',
           },
         ],
@@ -151,16 +174,29 @@ const scenes: Scene[] = [
       {
         kind: 'output',
         delay: 550,
+        segments: [{ text: '🪙  RESOLVING SECRETS', cls: 'highlight' }],
+      },
+      {
+        kind: 'output',
+        segments: [{ text: cliRule, cls: 'highlight' }],
+      },
+      {
+        kind: 'output',
         segments: [
-          { text: 'OPENAI_API_KEY', cls: 'command' },
-          { text: '=************************lu3', cls: 'output' },
+          { text: '  ✓ ', cls: 'flag' },
+          { text: 'OPENAI_API_KEY'.padEnd(20), cls: 'command' },
+          { text: '→ ************************lu3', cls: 'output' },
         ],
       },
+      { kind: 'blank' },
       {
         kind: 'output',
         delay: 220,
         segments: [
-          { text: "Environment File generated at '.env'", cls: 'highlight' },
+          { text: '⭐ LEVEL CLEARED', cls: 'highlight' },
+          { text: '  —  1/1 secrets loaded · ', cls: 'output' },
+          { text: '.env', cls: 'command' },
+          { text: ' written', cls: 'output' },
         ],
       },
     ],
@@ -568,7 +604,8 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
 
   .hero-term-screen {
     display: block;
-    min-height: 21em;
+    height: 21em;
+    overflow: hidden;
   }
 
   .hero-term-screen :global(.line) {
@@ -703,6 +740,7 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
     let current = 0;
     let paused = false;
     let holdTimer: ReturnType<typeof setTimeout> | undefined;
+    let scrollFrame: number | undefined;
 
     const sleep = (ms: number) =>
       new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -733,10 +771,19 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
       });
     }
 
+    function keepLatestLineVisible(): void {
+      if (scrollFrame !== undefined) return;
+      scrollFrame = window.requestAnimationFrame(() => {
+        screen!.scrollTop = screen!.scrollHeight;
+        scrollFrame = undefined;
+      });
+    }
+
     function makeLineEl(): HTMLElement {
       const el = document.createElement('span');
       el.className = 'line';
       screen!.appendChild(el);
+      keepLatestLineVisible();
       return el;
     }
 
@@ -758,6 +805,7 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
       const prompt = makeLineEl();
       prompt.innerHTML =
         '<span class="prompt">❯</span><span class="cursor"></span>';
+      keepLatestLineVisible();
     }
 
     function scheduleNext(index: number) {
@@ -807,12 +855,14 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
       const span = appendSeg(el, seg, cursor);
       if (seg.instant) {
         span.textContent = seg.text;
+        keepLatestLineVisible();
         return true;
       }
       for (const ch of seg.text) {
         await waitWhilePaused();
         if (!alive(id)) return false;
         span.textContent += ch;
+        keepLatestLineVisible();
         await sleep(typeDelay());
       }
       return true;
@@ -908,6 +958,7 @@ const scenesJson = JSON.stringify(scenes).replace(/</g, '\\u003c');
       if (!alive(id)) return;
 
       screen!.innerHTML = '';
+      screen!.scrollTop = 0;
       const cursor = document.createElement('span');
       cursor.className = 'cursor';
 


### PR DESCRIPTION
## Summary

Stabilizes the animated hero terminal so scene playback no longer changes page height or triggers mobile scroll anchoring. The terminal demo now mirrors the current Envilder CLI output for pull and single-secret push operations.

## Changes

- Keep the terminal viewport at a fixed height and follow the latest rendered line without creating a nested touch-scroll area.
- Update the setup scene to show the current `PUSHING SECRET` and `SECRET PUSHED` output.
- Update the CLI scene to show the current `RESOLVING SECRETS` and `LEVEL CLEARED` output.

## Testing

- [x] `pnpm --dir src/website format:check`
- [x] `pnpm --dir src/website lint`
- [x] `pnpm --dir src/website build`
- [x] `pnpm lint`
- [x] `pnpm test` (353 passed)
- [x] Responsive browser validation at 375x812, 768x1024, and 1440x900 in retro and light themes
- [x] Mobile scroll measurement remains stable across a complete terminal rotation
- [ ] `pnpm verify:gha` (the bundle regenerated from `main` differs from the versioned bundle; this PR has no GitHub Action diff)

## Related

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the hero terminal animation with clearer, step-by-step setup, push, and resolution output.
  * Added visual separators and highlighted status messages to make terminal activity easier to follow.
  * Updated terminal playback to automatically keep the latest output visible.
  * Refined terminal screen sizing and overflow behavior for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->