### PR TITLE
fix(website): improve crawlability and indexing

### DIFF
--- a/src/iac/lib/stacks/cloudfront-url-rewrite.js
+++ b/src/iac/lib/stacks/cloudfront-url-rewrite.js
@@ -53,18 +53,25 @@ function handler(event) {
 		for (var key in querystring) {
 			if (Object.prototype.hasOwnProperty.call(querystring, key)) {
 				var parameter = querystring[key];
-				var values = parameter.multiValue || [parameter];
+				if (parameter == null || typeof parameter !== "object") {
+					continue;
+				}
+				var values = Array.isArray(parameter.multiValue)
+					? parameter.multiValue
+					: [parameter];
 
 				for (var i = 0; i < values.length; i++) {
+					var entry = values[i];
+					if (entry == null || typeof entry !== "object") {
+						continue;
+					}
 					var hasValue = Object.prototype.hasOwnProperty.call(
-						values[i],
+						entry,
 						"value",
 					);
 					parts.push(
 						encodeURIComponent(key) +
-							(hasValue
-								? "=" + encodeURIComponent(values[i].value)
-								: ""),
+							(hasValue ? "=" + encodeURIComponent(entry.value) : ""),
 					);
 				}
 			}

--- a/src/iac/lib/stacks/cloudfront-url-rewrite.js
+++ b/src/iac/lib/stacks/cloudfront-url-rewrite.js
@@ -1,7 +1,3 @@
-// CloudFront Function for URL rewriting
-// Compatible with CloudFront Functions runtime (ES5.1)
-// Query strings are automatically preserved by CloudFront
-
 function handler(event) {
 	var req = event.request;
 	var uri = req.uri;
@@ -48,22 +44,56 @@ function handler(event) {
 		return false;
 	}
 
+	function getQueryString(querystring) {
+		if (typeof querystring === "string") {
+			return querystring ? "?" + querystring : "";
+		}
+
+		var parts = [];
+		for (var key in querystring) {
+			if (Object.prototype.hasOwnProperty.call(querystring, key)) {
+				var parameter = querystring[key];
+				var values = parameter.multiValue || [parameter];
+
+				for (var i = 0; i < values.length; i++) {
+					var value = values[i].value;
+					parts.push(key + (value ? "=" + value : ""));
+				}
+			}
+		}
+
+		return parts.length ? "?" + parts.join("&") : "";
+	}
+
+	function redirect(path) {
+		return {
+			statusCode: 301,
+			statusDescription: "Moved Permanently",
+			headers: {
+				location: {
+					value: path + getQueryString(req.querystring),
+				},
+			},
+		};
+	}
+
+	if (uri === "/sitemap.xml") {
+		return redirect("/sitemap-index.xml");
+	}
+
 	// Exclude API routes
 	var lower = uri.toLowerCase();
 	if (hasPrefix(lower, "/api/")) {
 		return req; // no changes
 	}
 
-	// Remove trailing slash (except homepage)
-	if (uri !== "/" && endsWith(uri, "/")) {
-		uri = uri.substring(0, uri.length - 1);
-		lower = uri.toLowerCase(); // recompute after modifying uri
-	}
-
-	// Append /index.html if not homepage and no known extension
-	// Astro generates directory-based URLs: /docs → /docs/index.html
+	// Astro generates directory-based URLs with trailing slashes.
 	if (uri !== "/" && !hasKnownExt(lower)) {
-		uri += "/index.html";
+		if (!endsWith(uri, "/")) {
+			return redirect(uri + "/");
+		}
+
+		uri += "index.html";
 	}
 
 	req.uri = uri;

--- a/src/iac/lib/stacks/cloudfront-url-rewrite.js
+++ b/src/iac/lib/stacks/cloudfront-url-rewrite.js
@@ -56,8 +56,16 @@ function handler(event) {
 				var values = parameter.multiValue || [parameter];
 
 				for (var i = 0; i < values.length; i++) {
-					var value = values[i].value;
-					parts.push(key + (value ? "=" + value : ""));
+					var hasValue = Object.prototype.hasOwnProperty.call(
+						values[i],
+						"value",
+					);
+					parts.push(
+						encodeURIComponent(key) +
+							(hasValue
+								? "=" + encodeURIComponent(values[i].value)
+								: ""),
+					);
 				}
 			}
 		}

--- a/src/iac/lib/stacks/staticWebsiteStack.ts
+++ b/src/iac/lib/stacks/staticWebsiteStack.ts
@@ -134,15 +134,15 @@ export class StaticWebsiteStack extends CustomStack {
 
 		const errorResponse403: ErrorResponse = {
 			httpStatus: 403,
-			responseHttpStatus: 200,
-			responsePagePath: "/index.html",
+			responseHttpStatus: 404,
+			responsePagePath: "/404.html",
 			ttl: Duration.seconds(10),
 		};
 
 		const errorResponse404: ErrorResponse = {
 			httpStatus: 404,
-			responseHttpStatus: 200,
-			responsePagePath: "/index.html",
+			responseHttpStatus: 404,
+			responsePagePath: "/404.html",
 			ttl: Duration.seconds(10),
 		};
 

--- a/src/website/public/llms.txt
+++ b/src/website/public/llms.txt
@@ -2,12 +2,23 @@
 
 > Envilder is MIT-licensed, open-source mapping and secret-resolution tooling for AWS SSM Parameter Store and Azure Key Vault. One `envilder.json` mapping contract is used across local development, CI/CD, and application startup.
 
-- Envilder is a mapping and resolution layer, not a secret manager, hosted SaaS, proxy, or control plane. The cloud provider remains the source of truth: Envilder has no hosted secret store or proxy, although the CLI can materialize a local `.env` file when requested.
-- Shipped surfaces: the CLI pulls mapped values to `.env` and supports intentional controlled push; the GitHub Action pulls mapped values to `.env` in CI/CD; .NET, Python, and Node.js runtime SDKs resolve values in-process and can return them or inject process environment variables. The .NET SDK also integrates with configuration and dependency injection APIs.
+- Scope: Envilder is a mapping and resolution layer, not a secret manager, hosted SaaS, proxy, or control plane. The cloud provider remains the source of truth; Envilder has no hosted secret store or proxy.
+- CLI: pulls mapped values to `.env` and supports intentional controlled push.
+- GitHub Action: pulls mapped values to `.env` in CI/CD.
+- Runtime SDKs: .NET, Python, and Node.js resolve values in-process and can return them or inject process environment variables. The .NET SDK also integrates with configuration and dependency injection APIs.
 - Best fit: small teams, projects, or straightforward applications already using SSM or Key Vault that want a version-controlled, PR-reviewable mapping without a separate hosted service. Container and Kubernetes workloads can use runtime SDKs with provider-native identity, but this is application-side resolution, not a native Kubernetes Secret sync, operator, or controller.
 - It is not the primary fit when the required backend is unsupported, a hosted or full secret-management control plane is needed, or native Kubernetes secret synchronization is required.
 - Google Cloud Secret Manager and AWS Secrets Manager are roadmap items; neither is shipped or scheduled. Request unsupported providers or integrations through the [GitHub issue form](https://github.com/macalbert/envilder/issues/new); requests help prioritize work but do not guarantee implementation.
 - Typical CLI flow: configure cloud credentials, keep secret values in the supported cloud store, commit only names and paths in `envilder.json`, then run `npx envilder --map=envilder.json --envfile=.env`. Use the GitHub Action for CI/CD or a runtime SDK for in-process resolution.
+
+Minimal AWS SSM map:
+
+```json
+{
+  "$schema": "https://envilder.com/schema/map-file.v1.json",
+  "DB_PASSWORD": "/my-app/prod/db-password"
+}
+```
 
 ## Start here
 

--- a/src/website/public/llms.txt
+++ b/src/website/public/llms.txt
@@ -1,0 +1,28 @@
+# Envilder
+
+> Envilder is an open-source secret resolution tool for applications that use AWS SSM Parameter Store or Azure Key Vault.
+
+## What Envilder does
+
+Envilder keeps a version-controlled JSON mapping between environment-variable names and secret paths. It resolves that mapping consistently during local development, CI/CD, and application startup.
+
+- Envilder does not store or proxy secret values.
+- Secrets remain in AWS SSM Parameter Store or Azure Key Vault.
+- The CLI supports pull and push workflows.
+- The GitHub Action supports pull workflows for CI/CD.
+- Runtime SDKs are available for .NET, Python, and Node.js.
+
+## Official resources
+
+- Product overview: https://envilder.com/
+- Documentation: https://envilder.com/docs/
+- Changelog: https://envilder.com/changelog/
+- Source repository: https://github.com/macalbert/envilder
+- Mapping schema: https://envilder.com/schema/map-file.v1.json
+
+## Product terminology
+
+- `envilder.json`: the JSON mapping file that defines the environment contract.
+- AWS SSM Parameter Store: a supported secret provider.
+- Azure Key Vault: a supported secret provider.
+- Runtime SDK: a library that resolves mapped secrets directly in an application process.

--- a/src/website/public/llms.txt
+++ b/src/website/public/llms.txt
@@ -1,28 +1,59 @@
 # Envilder
 
-> Envilder is an open-source secret resolution tool for applications that use AWS SSM Parameter Store or Azure Key Vault.
+> Envilder is MIT-licensed, open-source mapping and secret-resolution tooling for AWS SSM Parameter Store and Azure Key Vault. One `envilder.json` mapping contract is used across local development, CI/CD, and application startup.
 
-## What Envilder does
+- Envilder is a mapping and resolution layer, not a secret manager, hosted SaaS, proxy, or control plane. The cloud provider remains the source of truth: Envilder has no hosted secret store or proxy, although the CLI can materialize a local `.env` file when requested.
+- Shipped surfaces: the CLI pulls mapped values to `.env` and supports intentional controlled push; the GitHub Action pulls mapped values to `.env` in CI/CD; .NET, Python, and Node.js runtime SDKs resolve values in-process and can return them or inject process environment variables. The .NET SDK also integrates with configuration and dependency injection APIs.
+- Best fit: small teams, projects, or straightforward applications already using SSM or Key Vault that want a version-controlled, PR-reviewable mapping without a separate hosted service. Container and Kubernetes workloads can use runtime SDKs with provider-native identity, but this is application-side resolution, not a native Kubernetes Secret sync, operator, or controller.
+- It is not the primary fit when the required backend is unsupported, a hosted or full secret-management control plane is needed, or native Kubernetes secret synchronization is required.
+- Google Cloud Secret Manager and AWS Secrets Manager are roadmap items; neither is shipped or scheduled. Request unsupported providers or integrations through the [GitHub issue form](https://github.com/macalbert/envilder/issues/new); requests help prioritize work but do not guarantee implementation.
+- Typical CLI flow: configure cloud credentials, keep secret values in the supported cloud store, commit only names and paths in `envilder.json`, then run `npx envilder --map=envilder.json --envfile=.env`. Use the GitHub Action for CI/CD or a runtime SDK for in-process resolution.
 
-Envilder keeps a version-controlled JSON mapping between environment-variable names and secret paths. It resolves that mapping consistently during local development, CI/CD, and application startup.
+## Start here
 
-- Envilder does not store or proxy secret values.
-- Secrets remain in AWS SSM Parameter Store or Azure Key Vault.
-- The CLI supports pull and push workflows.
-- The GitHub Action supports pull workflows for CI/CD.
-- Runtime SDKs are available for .NET, Python, and Node.js.
+- [Product overview](https://envilder.com/): Envilder's website and product introduction.
+- [Website documentation](https://envilder.com/docs/): Documentation hub.
+- [Source repository](https://github.com/macalbert/envilder): Project source, issues, releases, and contribution history.
+- [Canonical README](https://raw.githubusercontent.com/macalbert/envilder/main/README.md): Primary repository overview in Markdown.
+- [Map-file JSON Schema](https://envilder.com/schema/map-file.v1.json): Schema for `envilder.json`.
 
-## Official resources
+## CLI and CI/CD
 
-- Product overview: https://envilder.com/
-- Documentation: https://envilder.com/docs/
-- Changelog: https://envilder.com/changelog/
-- Source repository: https://github.com/macalbert/envilder
-- Mapping schema: https://envilder.com/schema/map-file.v1.json
+- [Installation requirements](https://raw.githubusercontent.com/macalbert/envilder/main/docs/requirements-installation.md): CLI prerequisites and installation guidance.
+- [Pull command guide](https://raw.githubusercontent.com/macalbert/envilder/main/docs/pull-command.md): Resolve mapped values into a `.env` file.
+- [Push command guide](https://raw.githubusercontent.com/macalbert/envilder/main/docs/push-command.md): Intentional controlled CLI push workflows.
+- [GitHub Action documentation](https://raw.githubusercontent.com/macalbert/envilder/main/github-action/README.md): Pull-only CI/CD action usage.
 
-## Product terminology
+## Runtime SDKs
 
-- `envilder.json`: the JSON mapping file that defines the environment contract.
-- AWS SSM Parameter Store: a supported secret provider.
-- Azure Key Vault: a supported secret provider.
-- Runtime SDK: a library that resolves mapped secrets directly in an application process.
+- [.NET SDK documentation](https://raw.githubusercontent.com/macalbert/envilder/main/src/sdks/dotnet/README.md): Runtime resolution for .NET applications.
+- [Python SDK documentation](https://raw.githubusercontent.com/macalbert/envilder/main/src/sdks/python/README.md): Runtime resolution for Python applications.
+- [Node.js SDK documentation](https://raw.githubusercontent.com/macalbert/envilder/main/src/sdks/nodejs/README.md): Runtime resolution for Node.js applications.
+
+## Published packages
+
+- [CLI on npm](https://www.npmjs.com/package/envilder): Install the CLI package `envilder`.
+- [.NET SDK on NuGet](https://www.nuget.org/packages/Envilder/): Install the .NET runtime SDK package `Envilder`.
+- [Python SDK on PyPI](https://pypi.org/project/envilder/): Install the Python runtime SDK package `envilder`.
+- [Node.js SDK on npm](https://www.npmjs.com/package/@envilder/sdk): Install the Node.js runtime SDK package `@envilder/sdk`.
+
+## Examples
+
+- [Examples README](https://raw.githubusercontent.com/macalbert/envilder-examples/main/README.md): Reproducible .NET, Python, and TypeScript examples using Testcontainers and LocalStack, plus .NET and TypeScript Aspire examples; paths, not values, are committed.
+- [Examples repository](https://github.com/macalbert/envilder-examples): Source for the supported example scope above.
+
+## Project status and contribution
+
+- [Roadmap](https://raw.githubusercontent.com/macalbert/envilder/main/ROADMAP.md): Planned and in-progress work; roadmap items are not release commitments.
+- [Changelog](https://envilder.com/changelog/): Released changes.
+- [MIT license](https://raw.githubusercontent.com/macalbert/envilder/main/LICENSE): Terms for using, modifying, and distributing Envilder.
+- [Security policy](https://raw.githubusercontent.com/macalbert/envilder/main/docs/SECURITY.md): Vulnerability reporting guidance.
+- [Contributing guide](https://raw.githubusercontent.com/macalbert/envilder/main/CONTRIBUTING.md): Contribution process and local development guidance.
+- [Feature request or issue](https://github.com/macalbert/envilder/issues/new): Request an unsupported provider or integration, or report a problem.
+
+## Optional
+
+- [LocalStack token hygiene](https://dev.to/macalbert/how-i-run-localstack-without-committing-localstackauthtoken-34gk): Maintainer-authored supplementary article on keeping `LOCALSTACK_AUTH_TOKEN` out of commits.
+- [LocalStack integration tests without env files](https://dev.to/macalbert/localstack-integration-tests-without-env-files-b75): Maintainer-authored supplementary article.
+- [One year of Envilder](https://dev.to/macalbert/one-year-of-envilder-from-a-cli-script-to-sdks-push-mode-and-a-website-h49): Maintainer-authored supplementary retrospective.
+- [Original AWS SSM CLI workflow](https://dev.to/macalbert/stop-hardcoding-secrets-generate-env-files-from-aws-ssm-with-a-simple-cli-f77): Maintainer-authored supplementary historical context documenting the original AWS SSM CLI workflow.

--- a/src/website/public/robots.txt
+++ b/src/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://envilder.com/sitemap-index.xml

--- a/src/website/src/i18n/ca.ts
+++ b/src/website/src/i18n/ca.ts
@@ -3,9 +3,16 @@ import type { Translations } from './types';
 export const ca: Translations = {
   homeMeta: {
     title:
-      'Envilder: estandarditza com les teves aplicacions consumeixen secrets a cada entorn i runtime.',
+      'Gestió de secrets open source per a AWS SSM i Azure Key Vault | Envilder',
     description:
-      "Defineix el contracte d'entorn una vegada i resol-lo de forma consistent en desenvolupament local, CI/CD i runtime. Amb AWS SSM Parameter Store i Azure Key Vault.",
+      "Envilder és una CLI, GitHub Action i SDK de runtime open source per carregar secrets des d'AWS SSM Parameter Store i Azure Key Vault.",
+  },
+  notFound: {
+    title: 'Pàgina no trobada | Envilder',
+    description: "La pàgina d'Envilder sol·licitada no existeix.",
+    heading: 'No hem trobat aquesta pàgina',
+    body: "L'adreça pot ser incorrecta o la pàgina pot haver-se mogut.",
+    home: 'Torna a l’inici',
   },
   nav: {
     features: 'Funcionalitats',
@@ -451,7 +458,9 @@ export const ca: Translations = {
     builtWith: 'Fet amb Astro. Codi obert a GitHub.',
   },
   changelogPage: {
-    title: 'Changelog Envilder | Versions i actualitzacions',
+    title: 'Canvis d’Envilder: versions de la CLI, GitHub Action i SDKs',
+    description:
+      "Historial de versions de la CLI, GitHub Action i SDKs de runtime .NET, Python i Node.js d'Envilder.",
 
     backToHome: "← Tornar a l'inici",
     fullChangelog: 'Historial de ',
@@ -468,7 +477,9 @@ export const ca: Translations = {
     categorySdkNodejs: 'Node.js',
   },
   docs: {
-    title: 'Docs Envilder | CLI, GitHub Action i AWS SSM',
+    title: 'Docs Envilder: secrets amb AWS SSM i Azure Key Vault',
+    description:
+      "Aprèn a resoldre variables d'entorn des d'AWS SSM Parameter Store i Azure Key Vault amb la CLI, GitHub Action i SDKs de runtime d'Envilder.",
 
     backToHome: "← Tornar a l'inici",
     pageTitle: 'Documentació',

--- a/src/website/src/i18n/en.ts
+++ b/src/website/src/i18n/en.ts
@@ -3,9 +3,16 @@ import type { Translations } from './types';
 export const en: Translations = {
   homeMeta: {
     title:
-      'Envilder: standardize how your applications consume secrets across every environment and runtime.',
+      'Open-source secret management for AWS SSM and Azure Key Vault | Envilder',
     description:
-      'Define your environment contract once and resolve it consistently across local development, CI/CD, and runtime. Using AWS SSM Parameter Store and Azure Key Vault.',
+      'Envilder is an open-source CLI, GitHub Action, and runtime SDK for loading secrets from AWS SSM Parameter Store and Azure Key Vault.',
+  },
+  notFound: {
+    title: 'Page not found | Envilder',
+    description: 'The requested Envilder page does not exist.',
+    heading: 'This page was not found',
+    body: 'The address may be incorrect, or the page may have moved.',
+    home: 'Return home',
   },
   nav: {
     features: 'Features',
@@ -450,7 +457,9 @@ export const en: Translations = {
     builtWith: 'Built with Astro. Open source on GitHub.',
   },
   changelogPage: {
-    title: 'Envilder Changelog | Releases & Updates',
+    title: 'Envilder changelog: CLI, GitHub Action, and SDK releases',
+    description:
+      'Release history for the Envilder CLI, GitHub Action, and .NET, Python, and Node.js runtime SDKs.',
 
     backToHome: '← Back to home',
     fullChangelog: 'Full ',
@@ -467,7 +476,9 @@ export const en: Translations = {
     categorySdkNodejs: 'Node.js',
   },
   docs: {
-    title: 'Envilder Docs | CLI, GitHub Action & AWS SSM',
+    title: 'Envilder docs: AWS SSM and Azure Key Vault secrets',
+    description:
+      'Learn how to resolve environment variables from AWS SSM Parameter Store and Azure Key Vault with the Envilder CLI, GitHub Action, and runtime SDKs.',
 
     backToHome: '← Back to home',
     pageTitle: 'Documentation',

--- a/src/website/src/i18n/es.ts
+++ b/src/website/src/i18n/es.ts
@@ -3,9 +3,16 @@ import type { Translations } from './types';
 export const es: Translations = {
   homeMeta: {
     title:
-      'Envilder: estandariza cómo tus aplicaciones consumen secretos en cada entorno y runtime.',
+      'Gestión de secretos open source para AWS SSM y Azure Key Vault | Envilder',
     description:
-      'Define tu contrato de entorno una vez y resuélvelo de forma consistente en desarrollo local, CI/CD y runtime. Con AWS SSM Parameter Store y Azure Key Vault.',
+      'Envilder es una CLI, GitHub Action y SDK de runtime open source para cargar secretos desde AWS SSM Parameter Store y Azure Key Vault.',
+  },
+  notFound: {
+    title: 'Página no encontrada | Envilder',
+    description: 'La página de Envilder solicitada no existe.',
+    heading: 'No hemos encontrado esta página',
+    body: 'La dirección puede ser incorrecta o la página puede haberse movido.',
+    home: 'Volver al inicio',
   },
   nav: {
     features: 'Funcionalidades',
@@ -451,7 +458,9 @@ export const es: Translations = {
     builtWith: 'Hecho con Astro. Código abierto en GitHub.',
   },
   changelogPage: {
-    title: 'Changelog Envilder | Versiones y actualizaciones',
+    title: 'Cambios de Envilder: versiones de la CLI, GitHub Action y SDKs',
+    description:
+      'Historial de versiones de la CLI, GitHub Action y SDKs de runtime .NET, Python y Node.js de Envilder.',
 
     backToHome: '← Volver al inicio',
     fullChangelog: 'Historial de ',
@@ -468,7 +477,9 @@ export const es: Translations = {
     categorySdkNodejs: 'Node.js',
   },
   docs: {
-    title: 'Docs Envilder | CLI, GitHub Action y AWS SSM',
+    title: 'Docs Envilder: secretos con AWS SSM y Azure Key Vault',
+    description:
+      'Aprende a resolver variables de entorno desde AWS SSM Parameter Store y Azure Key Vault con la CLI, GitHub Action y SDKs de runtime de Envilder.',
 
     backToHome: '← Volver al inicio',
     pageTitle: 'Documentación',

--- a/src/website/src/i18n/types.ts
+++ b/src/website/src/i18n/types.ts
@@ -253,6 +253,7 @@ export interface FooterTranslations {
 
 export interface ChangelogPageTranslations {
   title: string;
+  description: string;
   backToHome: string;
   fullChangelog: string;
   changelogAccent: string;
@@ -270,6 +271,7 @@ export interface ChangelogPageTranslations {
 
 export interface DocsTranslations {
   title: string;
+  description: string;
   backToHome: string;
   pageTitle: string;
   intro: string;
@@ -533,6 +535,14 @@ export interface HomeMetaTranslations {
   description: string;
 }
 
+export interface NotFoundTranslations {
+  title: string;
+  description: string;
+  heading: string;
+  body: string;
+  home: string;
+}
+
 export interface SponsorsTranslations {
   title: string;
   localstackAlt: string;
@@ -542,6 +552,7 @@ export interface SponsorsTranslations {
 
 export interface Translations {
   homeMeta: HomeMetaTranslations;
+  notFound: NotFoundTranslations;
   nav: NavLinks;
   theme: ThemeTranslations;
   hero: HeroTranslations;

--- a/src/website/src/layouts/BaseLayout.astro
+++ b/src/website/src/layouts/BaseLayout.astro
@@ -3,12 +3,14 @@ export interface Props {
   title?: string;
   description?: string;
   lang?: string;
+  noindex?: boolean;
 }
 
 const {
   title = 'Envilder: centralize your secrets. One command.',
   description = 'A CLI tool and GitHub Action that securely centralizes environment variables from AWS SSM Parameter Store or Azure Key Vault as a single source of truth.',
   lang = 'en',
+  noindex = false,
 } = Astro.props;
 
 const skipLabel: Record<string, string> = {
@@ -18,7 +20,70 @@ const skipLabel: Record<string, string> = {
 };
 const skipText = skipLabel[lang] ?? skipLabel.en;
 
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const siteUrl = Astro.site ?? 'https://envilder.com';
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
+const siteRootUrl = new URL('/', siteUrl).href;
+const pathWithoutLocale =
+  Astro.url.pathname.replace(/^\/(?:ca|es)(?=\/|$)/, '') || '/';
+const alternateLanguages = ['en', 'ca', 'es'].map((language) => ({
+  language,
+  href: new URL(
+    language === 'en' ? pathWithoutLocale : `/${language}${pathWithoutLocale}`,
+    siteUrl,
+  ).href,
+}));
+const isHomePage = pathWithoutLocale === '/';
+const structuredData = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': `${siteRootUrl}#organization`,
+      name: 'Envilder',
+      url: siteRootUrl,
+      sameAs: ['https://github.com/macalbert/envilder'],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${siteRootUrl}#website`,
+      name: 'Envilder',
+      url: siteRootUrl,
+      publisher: {
+        '@id': `${siteRootUrl}#organization`,
+      },
+    },
+    ...(!noindex
+      ? [
+          {
+            '@type': 'WebPage',
+            '@id': `${canonicalUrl}#webpage`,
+            url: canonicalUrl,
+            name: title,
+            description,
+            inLanguage: lang,
+            isPartOf: {
+              '@id': `${siteRootUrl}#website`,
+            },
+          },
+        ]
+      : []),
+    ...(isHomePage && !noindex
+      ? [
+          {
+            '@type': 'SoftwareApplication',
+            '@id': `${siteRootUrl}#software`,
+            name: 'Envilder',
+            description,
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'Windows, macOS, Linux',
+            isAccessibleForFree: true,
+            codeRepository: 'https://github.com/macalbert/envilder',
+            license: 'https://github.com/macalbert/envilder/blob/main/LICENSE',
+          },
+        ]
+      : []),
+  ],
+});
 ---
 
 <!doctype html>
@@ -29,6 +94,18 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
     <meta name="description" content={description} />
     <meta name="author" content="Marçal Albert Castellví" />
     <meta name="generator" content={Astro.generator} />
+    {noindex && <meta name="robots" content="noindex,follow" />}
+    <link rel="canonical" href={canonicalUrl} />
+    {!noindex &&
+      alternateLanguages.map((alternate) => (
+        <link
+          rel="alternate"
+          hreflang={alternate.language}
+          href={alternate.href}
+        />
+      ))}
+    {!noindex && <link rel="alternate" hreflang="x-default" href={alternateLanguages[0].href} />}
+    <script type="application/ld+json" set:html={structuredData}></script>
 
     <!-- OG -->
     <meta property="og:type" content="website" />

--- a/src/website/src/layouts/BaseLayout.astro
+++ b/src/website/src/layouts/BaseLayout.astro
@@ -1,4 +1,6 @@
 ---
+import { defaultLang, languages } from '../i18n/utils';
+
 export interface Props {
   title?: string;
   description?: string;
@@ -23,12 +25,24 @@ const skipText = skipLabel[lang] ?? skipLabel.en;
 const siteUrl = Astro.site ?? 'https://envilder.com';
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 const siteRootUrl = new URL('/', siteUrl).href;
-const pathWithoutLocale =
-  Astro.url.pathname.replace(/^\/(?:ca|es)(?=\/|$)/, '') || '/';
-const alternateLanguages = ['en', 'ca', 'es'].map((language) => ({
+const alternateLanguages = Object.keys(languages);
+const localizedLanguages = alternateLanguages.filter(
+  (language) => language !== defaultLang,
+);
+const localizedLanguagePattern = localizedLanguages.join('|');
+const pathWithoutLocale = localizedLanguagePattern
+  ? Astro.url.pathname.replace(
+      new RegExp(`^/(?:${localizedLanguagePattern})(?=/|$)`),
+      '',
+    ) || '/'
+  : Astro.url.pathname;
+const defaultLanguageUrl = new URL(pathWithoutLocale, siteUrl).href;
+const alternateLanguageUrls = alternateLanguages.map((language) => ({
   language,
   href: new URL(
-    language === 'en' ? pathWithoutLocale : `/${language}${pathWithoutLocale}`,
+    language === defaultLang
+      ? pathWithoutLocale
+      : `/${language}${pathWithoutLocale}`,
     siteUrl,
   ).href,
 }));
@@ -97,14 +111,14 @@ const structuredData = JSON.stringify({
     {noindex && <meta name="robots" content="noindex,follow" />}
     <link rel="canonical" href={canonicalUrl} />
     {!noindex &&
-      alternateLanguages.map((alternate) => (
+      alternateLanguageUrls.map((alternate) => (
         <link
           rel="alternate"
           hreflang={alternate.language}
           href={alternate.href}
         />
       ))}
-    {!noindex && <link rel="alternate" hreflang="x-default" href={alternateLanguages[0].href} />}
+    {!noindex && <link rel="alternate" hreflang="x-default" href={defaultLanguageUrl} />}
     <script type="application/ld+json" set:html={structuredData}></script>
 
     <!-- OG -->

--- a/src/website/src/pages/404.astro
+++ b/src/website/src/pages/404.astro
@@ -1,0 +1,60 @@
+---
+import Footer from '../components/Footer.astro';
+import Navbar from '../components/Navbar.astro';
+import { useTranslations } from '../i18n/utils';
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const lang = 'en';
+const t = useTranslations(lang);
+---
+
+<BaseLayout
+  title={t.notFound.title}
+  description={t.notFound.description}
+  lang={lang}
+  noindex
+>
+  <Navbar lang={lang} />
+  <main class="not-found-page" id="main-content">
+    <section class="section">
+      <div class="container">
+        <div class="not-found-content pixel-card">
+          <p class="not-found-code">404</p>
+          <h1>{t.notFound.heading}</h1>
+          <p>{t.notFound.body}</p>
+          <a class="btn btn-primary" href="/">{t.notFound.home}</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer lang={lang} />
+</BaseLayout>
+
+<style>
+  .not-found-page {
+    min-height: 70vh;
+    padding-top: calc(var(--nav-height) + var(--space-3xl));
+  }
+
+  .not-found-content {
+    max-width: 42rem;
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .not-found-code {
+    margin-bottom: var(--space-md);
+    color: var(--color-primary);
+    font-family: var(--font-pixel);
+    font-size: clamp(2rem, 8vw, 4rem);
+  }
+
+  .not-found-content h1 {
+    margin-bottom: var(--space-md);
+  }
+
+  .not-found-content p:not(.not-found-code) {
+    margin-bottom: var(--space-xl);
+    color: var(--color-text-muted);
+  }
+</style>

--- a/src/website/src/pages/404.astro
+++ b/src/website/src/pages/404.astro
@@ -51,13 +51,22 @@ const notFoundTranslations = Object.fromEntries(
   document
     .querySelector('meta[name="description"]')
     ?.setAttribute('content', translation.description);
-  document.querySelector('[data-not-found-heading]').textContent =
-    translation.heading;
-  document.querySelector('[data-not-found-body]').textContent =
-    translation.body;
+  const heading = document.querySelector('[data-not-found-heading]');
+  const body = document.querySelector('[data-not-found-body]');
   const homeLink = document.querySelector('[data-not-found-home]');
-  homeLink.textContent = translation.home;
-  homeLink.setAttribute('href', homePath);
+
+  if (heading) {
+    heading.textContent = translation.heading;
+  }
+
+  if (body) {
+    body.textContent = translation.body;
+  }
+
+  if (homeLink) {
+    homeLink.textContent = translation.home;
+    homeLink.setAttribute('href', homePath);
+  }
 </script>
 
 <style>

--- a/src/website/src/pages/404.astro
+++ b/src/website/src/pages/404.astro
@@ -24,7 +24,7 @@ const notFoundTranslations = Object.fromEntries(
   <main class="not-found-page" id="main-content">
     <section class="section">
       <div class="container">
-        <div class="not-found-content pixel-card">
+        <div class="not-found-content pixel-card" data-not-found-content>
           <p class="not-found-code">404</p>
           <h1 data-not-found-heading>{t.notFound.heading}</h1>
           <p data-not-found-body>{t.notFound.body}</p>
@@ -44,7 +44,9 @@ const notFoundTranslations = Object.fromEntries(
   const translation = notFoundTranslations[locale];
   const homePath = locale === defaultLang ? '/' : `/${locale}/`;
 
-  document.documentElement.lang = locale;
+  document
+    .querySelector('[data-not-found-content]')
+    ?.setAttribute('lang', locale);
   document.title = translation.title;
   document
     .querySelector('meta[name="description"]')

--- a/src/website/src/pages/404.astro
+++ b/src/website/src/pages/404.astro
@@ -1,11 +1,17 @@
 ---
 import Footer from '../components/Footer.astro';
 import Navbar from '../components/Navbar.astro';
-import { useTranslations } from '../i18n/utils';
+import { defaultLang, languages, useTranslations } from '../i18n/utils';
 import BaseLayout from '../layouts/BaseLayout.astro';
 
-const lang = 'en';
+const lang = defaultLang;
 const t = useTranslations(lang);
+const notFoundTranslations = Object.fromEntries(
+  Object.keys(languages).map((locale) => [
+    locale,
+    useTranslations(locale).notFound,
+  ]),
+);
 ---
 
 <BaseLayout
@@ -20,15 +26,37 @@ const t = useTranslations(lang);
       <div class="container">
         <div class="not-found-content pixel-card">
           <p class="not-found-code">404</p>
-          <h1>{t.notFound.heading}</h1>
-          <p>{t.notFound.body}</p>
-          <a class="btn btn-primary" href="/">{t.notFound.home}</a>
+          <h1 data-not-found-heading>{t.notFound.heading}</h1>
+          <p data-not-found-body>{t.notFound.body}</p>
+          <a class="btn btn-primary" data-not-found-home href="/">{t.notFound.home}</a>
         </div>
       </div>
     </section>
   </main>
   <Footer lang={lang} />
 </BaseLayout>
+
+<script define:vars={{ defaultLang, notFoundTranslations }}>
+  const requestedLocale = window.location.pathname.split('/')[1];
+  const locale = Object.hasOwn(notFoundTranslations, requestedLocale)
+    ? requestedLocale
+    : defaultLang;
+  const translation = notFoundTranslations[locale];
+  const homePath = locale === defaultLang ? '/' : `/${locale}/`;
+
+  document.documentElement.lang = locale;
+  document.title = translation.title;
+  document
+    .querySelector('meta[name="description"]')
+    ?.setAttribute('content', translation.description);
+  document.querySelector('[data-not-found-heading]').textContent =
+    translation.heading;
+  document.querySelector('[data-not-found-body]').textContent =
+    translation.body;
+  const homeLink = document.querySelector('[data-not-found-home]');
+  homeLink.textContent = translation.home;
+  homeLink.setAttribute('href', homePath);
+</script>
 
 <style>
   .not-found-page {

--- a/src/website/src/pages/ca/changelog.astro
+++ b/src/website/src/pages/ca/changelog.astro
@@ -53,6 +53,7 @@ const parsedById = Object.fromEntries(parsed.map((p) => [p.id, p]));
 
 <BaseLayout
   title={t.changelogPage.title}
+  description={t.changelogPage.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/src/website/src/pages/ca/docs.astro
+++ b/src/website/src/pages/ca/docs.astro
@@ -11,6 +11,7 @@ const t = useTranslations(lang);
 
 <BaseLayout
   title={t.docs.title}
+  description={t.docs.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/src/website/src/pages/changelog.astro
+++ b/src/website/src/pages/changelog.astro
@@ -53,6 +53,7 @@ const parsedById = Object.fromEntries(parsed.map((p) => [p.id, p]));
 
 <BaseLayout
   title={t.changelogPage.title}
+  description={t.changelogPage.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/src/website/src/pages/docs.astro
+++ b/src/website/src/pages/docs.astro
@@ -11,6 +11,7 @@ const t = useTranslations(lang);
 
 <BaseLayout
   title={t.docs.title}
+  description={t.docs.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/src/website/src/pages/es/changelog.astro
+++ b/src/website/src/pages/es/changelog.astro
@@ -53,6 +53,7 @@ const parsedById = Object.fromEntries(parsed.map((p) => [p.id, p]));
 
 <BaseLayout
   title={t.changelogPage.title}
+  description={t.changelogPage.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/src/website/src/pages/es/docs.astro
+++ b/src/website/src/pages/es/docs.astro
@@ -11,6 +11,7 @@ const t = useTranslations(lang);
 
 <BaseLayout
   title={t.docs.title}
+  description={t.docs.description}
   lang={lang}
 >
   <Navbar lang={lang} />

--- a/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
+++ b/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
@@ -330,14 +330,14 @@ exports[`Static website Stack > Should_CreateWebsite_When_StackIsCalled > static
             {
               "ErrorCachingMinTTL": 10,
               "ErrorCode": 403,
-              "ResponseCode": 200,
-              "ResponsePagePath": "/index.html",
+              "ResponseCode": 404,
+              "ResponsePagePath": "/404.html",
             },
             {
               "ErrorCachingMinTTL": 10,
               "ErrorCode": 404,
-              "ResponseCode": 200,
-              "ResponsePagePath": "/index.html",
+              "ResponseCode": 404,
+              "ResponsePagePath": "/404.html",
             },
           ],
           "DefaultCacheBehavior": {
@@ -828,11 +828,7 @@ exports[`Static website Stack > Should_CreateWebsite_When_StackIsCalled > static
     "testdomaincomurlrewrite603CDF99": {
       "Properties": {
         "AutoPublish": true,
-        "FunctionCode": "// CloudFront Function for URL rewriting
-// Compatible with CloudFront Functions runtime (ES5.1)
-// Query strings are automatically preserved by CloudFront
-
-function handler(event) {
+        "FunctionCode": "function handler(event) {
 	var req = event.request;
 	var uri = req.uri;
 
@@ -878,22 +874,56 @@ function handler(event) {
 		return false;
 	}
 
+	function getQueryString(querystring) {
+		if (typeof querystring === "string") {
+			return querystring ? "?" + querystring : "";
+		}
+
+		var parts = [];
+		for (var key in querystring) {
+			if (Object.prototype.hasOwnProperty.call(querystring, key)) {
+				var parameter = querystring[key];
+				var values = parameter.multiValue || [parameter];
+
+				for (var i = 0; i < values.length; i++) {
+					var value = values[i].value;
+					parts.push(key + (value ? "=" + value : ""));
+				}
+			}
+		}
+
+		return parts.length ? "?" + parts.join("&") : "";
+	}
+
+	function redirect(path) {
+		return {
+			statusCode: 301,
+			statusDescription: "Moved Permanently",
+			headers: {
+				location: {
+					value: path + getQueryString(req.querystring),
+				},
+			},
+		};
+	}
+
+	if (uri === "/sitemap.xml") {
+		return redirect("/sitemap-index.xml");
+	}
+
 	// Exclude API routes
 	var lower = uri.toLowerCase();
 	if (hasPrefix(lower, "/api/")) {
 		return req; // no changes
 	}
 
-	// Remove trailing slash (except homepage)
-	if (uri !== "/" && endsWith(uri, "/")) {
-		uri = uri.substring(0, uri.length - 1);
-		lower = uri.toLowerCase(); // recompute after modifying uri
-	}
-
-	// Append /index.html if not homepage and no known extension
-	// Astro generates directory-based URLs: /docs → /docs/index.html
+	// Astro generates directory-based URLs with trailing slashes.
 	if (uri !== "/" && !hasKnownExt(lower)) {
-		uri += "/index.html";
+		if (!endsWith(uri, "/")) {
+			return redirect(uri + "/");
+		}
+
+		uri += "index.html";
 	}
 
 	req.uri = uri;

--- a/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
+++ b/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
@@ -886,8 +886,16 @@ exports[`Static website Stack > Should_CreateWebsite_When_StackIsCalled > static
 				var values = parameter.multiValue || [parameter];
 
 				for (var i = 0; i < values.length; i++) {
-					var value = values[i].value;
-					parts.push(key + (value ? "=" + value : ""));
+					var hasValue = Object.prototype.hasOwnProperty.call(
+						values[i],
+						"value",
+					);
+					parts.push(
+						encodeURIComponent(key) +
+							(hasValue
+								? "=" + encodeURIComponent(values[i].value)
+								: ""),
+					);
 				}
 			}
 		}

--- a/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
+++ b/tests/iac/lib/stacks/__snapshots__/staticWebsiteStack.test.ts.snap
@@ -883,18 +883,25 @@ exports[`Static website Stack > Should_CreateWebsite_When_StackIsCalled > static
 		for (var key in querystring) {
 			if (Object.prototype.hasOwnProperty.call(querystring, key)) {
 				var parameter = querystring[key];
-				var values = parameter.multiValue || [parameter];
+				if (parameter == null || typeof parameter !== "object") {
+					continue;
+				}
+				var values = Array.isArray(parameter.multiValue)
+					? parameter.multiValue
+					: [parameter];
 
 				for (var i = 0; i < values.length; i++) {
+					var entry = values[i];
+					if (entry == null || typeof entry !== "object") {
+						continue;
+					}
 					var hasValue = Object.prototype.hasOwnProperty.call(
-						values[i],
+						entry,
 						"value",
 					);
 					parts.push(
 						encodeURIComponent(key) +
-							(hasValue
-								? "=" + encodeURIComponent(values[i].value)
-								: ""),
+							(hasValue ? "=" + encodeURIComponent(entry.value) : ""),
 					);
 				}
 			}

--- a/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
+++ b/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
@@ -216,6 +216,36 @@ describe("CloudFront URL Rewrite Function", () => {
 		});
 	});
 
+	test("Should_SkipInvalidQueryEntries_When_QueryStringObjectContainsNullishValues", () => {
+		// Arrange
+		const event = {
+			request: {
+				uri: "/docs",
+				querystring: {
+					"search term": {
+						value: "hello world",
+					},
+					broken: null,
+					missing: undefined,
+				},
+			},
+		};
+		const expected = "/docs/?search%20term=hello%20world";
+
+		// Act
+		const actual = handlerFunc(event);
+
+		// Assert
+		expect(actual).toMatchObject({
+			statusCode: 301,
+			headers: {
+				location: {
+					value: expected,
+				},
+			},
+		});
+	});
+
 	test("Should_RedirectLegacySitemap_When_SitemapXmlIsRequested", () => {
 		// Arrange
 		const event = {

--- a/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
+++ b/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
@@ -133,6 +133,45 @@ describe("CloudFront URL Rewrite Function", () => {
 		});
 	});
 
+	test(
+		"Should_PercentEncodeQueryObjectParameters_When_RedirectingUrl",
+		() => {
+			// Arrange
+			const event = {
+				request: {
+					uri: "/docs",
+					querystring: {
+						"category name": {
+							value: "green tea&herbs",
+						},
+						flag: {},
+						empty: {
+							value: "",
+						},
+						"a&b": {
+							value: "c=d#f",
+						},
+					},
+				},
+			};
+			const expected =
+				"/docs/?category%20name=green%20tea%26herbs&flag&empty=&a%26b=c%3Dd%23f";
+
+			// Act
+			const actual = handlerFunc(event);
+
+			// Assert
+			expect(actual).toMatchObject({
+				statusCode: 301,
+				headers: {
+					location: {
+						value: expected,
+					},
+				},
+			});
+		},
+	);
+
 	test("Should_RedirectToTrailingSlash_When_PathHasNoFileExtension", () => {
 		// Arrange
 		const event = {

--- a/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
+++ b/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
@@ -2,6 +2,25 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("CloudFront URL Rewrite Function", () => {
+	interface CloudFrontRequest {
+		uri: string;
+		querystring: unknown;
+	}
+
+	interface CloudFrontRedirectResponse {
+		statusCode: number;
+		statusDescription: string;
+		headers: {
+			location: {
+				value: string;
+			};
+		};
+	}
+
+	type CloudFrontHandlerResult =
+		| CloudFrontRequest
+		| CloudFrontRedirectResponse;
+
 	const handlerPath = join(
 		__dirname,
 		"../../../../src/iac/lib/stacks/cloudfront-url-rewrite.js",
@@ -11,9 +30,9 @@ describe("CloudFront URL Rewrite Function", () => {
 	const handlerFunc = new Function(
 		"event",
 		`${handlerCode}; return handler(event);`,
-	) as (event: { request: { uri: string; querystring: unknown } }) => {
-		uri: string;
-	};
+	) as (event: {
+		request: CloudFrontRequest;
+	}) => CloudFrontHandlerResult;
 
 	interface TestCase {
 		input: string;
@@ -52,10 +71,12 @@ describe("CloudFront URL Rewrite Function", () => {
 		};
 
 		// Act
-		const result = handlerFunc(event);
+		const actual = handlerFunc(event);
 
 		// Assert
-		expect(result.uri).toBe(expectedUri);
+		expect(actual).toMatchObject({
+			uri: expectedUri,
+		});
 	});
 
 	test.each(

--- a/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
+++ b/tests/iac/lib/stacks/cloudfrontUrlRewrite.test.ts
@@ -11,7 +11,7 @@ describe("CloudFront URL Rewrite Function", () => {
 	const handlerFunc = new Function(
 		"event",
 		`${handlerCode}; return handler(event);`,
-	) as (event: { request: { uri: string; querystring: string } }) => {
+	) as (event: { request: { uri: string; querystring: unknown } }) => {
 		uri: string;
 	};
 
@@ -27,21 +27,15 @@ describe("CloudFront URL Rewrite Function", () => {
 
 	const testCases: TestCase[] = [
 		{ input: "/", expectedUri: "/" },
-		{ input: "/dashboard", expectedUri: "/dashboard/index.html" },
 		{ input: "/contact/", expectedUri: "/contact/index.html" },
 		{ input: "/app.js", expectedUri: "/app.js" },
 		{ input: "/api/users", expectedUri: "/api/users" },
-		{ input: "/folder/page", expectedUri: "/folder/page/index.html" },
 	];
 
 	const testCasesWithQueryString: TestCaseWithQueryString[] = [
 		{
 			input: "/contact?utm_source=x",
-			expectedVisible: "/contact/index.html?utm_source=x",
-		},
-		{
-			input: "/styles/main.css?ver=123",
-			expectedVisible: "/styles/main.css?ver=123",
+			expectedVisible: "/contact/?utm_source=x",
 		},
 	];
 
@@ -66,7 +60,7 @@ describe("CloudFront URL Rewrite Function", () => {
 
 	test.each(
 		testCasesWithQueryString,
-	)("Should_PreserveQueryStrings_When_UrlHasParameters_$input", ({
+	)("Should_PreserveQueryStrings_When_RedirectingUrl_$input", ({
 		input,
 		expectedVisible,
 	}) => {
@@ -80,12 +74,108 @@ describe("CloudFront URL Rewrite Function", () => {
 		};
 
 		// Act
-		const result = handlerFunc(event);
+		const actual = handlerFunc(event);
 
 		// Assert
-		const actualVisible = querystring
-			? `${result.uri}?${querystring}`
-			: result.uri;
-		expect(actualVisible).toBe(expectedVisible);
+		expect(actual).toMatchObject({
+			statusCode: 301,
+			headers: {
+				location: {
+					value: expectedVisible,
+				},
+			},
+		});
+	});
+
+	test("Should_KeepStaticUrl_When_StaticFileHasQueryString", () => {
+		// Arrange
+		const event = {
+			request: {
+				uri: "/styles/main.css",
+				querystring: "ver=123",
+			},
+		};
+
+		// Act
+		const actual = handlerFunc(event);
+
+		// Assert
+		expect(actual).toMatchObject({
+			uri: "/styles/main.css",
+			querystring: "ver=123",
+		});
+	});
+
+	test("Should_PreserveCloudFrontQueryObject_When_RedirectingUrl", () => {
+		// Arrange
+		const event = {
+			request: {
+				uri: "/docs",
+				querystring: {
+					utm_source: {
+						value: "search",
+					},
+				},
+			},
+		};
+
+		// Act
+		const actual = handlerFunc(event);
+
+		// Assert
+		expect(actual).toMatchObject({
+			statusCode: 301,
+			headers: {
+				location: {
+					value: "/docs/?utm_source=search",
+				},
+			},
+		});
+	});
+
+	test("Should_RedirectToTrailingSlash_When_PathHasNoFileExtension", () => {
+		// Arrange
+		const event = {
+			request: {
+				uri: "/docs",
+				querystring: "",
+			},
+		};
+
+		// Act
+		const actual = handlerFunc(event);
+
+		// Assert
+		expect(actual).toMatchObject({
+			statusCode: 301,
+			headers: {
+				location: {
+					value: "/docs/",
+				},
+			},
+		});
+	});
+
+	test("Should_RedirectLegacySitemap_When_SitemapXmlIsRequested", () => {
+		// Arrange
+		const event = {
+			request: {
+				uri: "/sitemap.xml",
+				querystring: "",
+			},
+		};
+
+		// Act
+		const actual = handlerFunc(event);
+
+		// Assert
+		expect(actual).toMatchObject({
+			statusCode: 301,
+			headers: {
+				location: {
+					value: "/sitemap-index.xml",
+				},
+			},
+		});
 	});
 });

--- a/tests/iac/lib/stacks/staticWebsiteStack.test.ts
+++ b/tests/iac/lib/stacks/staticWebsiteStack.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { App, Stack } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { AppEnvironment } from "../../../../src/iac/lib/core/types";
 import type { DomainConfig } from "../../../../src/iac/lib/stacks/customStack";
 import {
@@ -42,6 +42,37 @@ describe("Static website Stack", () => {
 		normalizeStaticWebsiteTemplate(template);
 
 		expect(template).toMatchSnapshot("staticWebsiteStackTest");
+	});
+
+	test("Should_ReturnNotFoundPage_When_OriginReturnsMissingObject", () => {
+		// Arrange
+		const stack = new Stack(new App(), "staticWebsiteStackTest", {
+			env: env,
+		});
+		const props = createStaticWebsiteStackProps();
+		const sut = new StaticWebsiteStack(stack, props);
+		const template = Template.fromStack(sut);
+
+		// Act
+		const actual = template;
+
+		// Assert
+		actual.hasResourceProperties("AWS::CloudFront::Distribution", {
+			DistributionConfig: Match.objectLike({
+				CustomErrorResponses: Match.arrayWith([
+					Match.objectLike({
+						ErrorCode: 403,
+						ResponseCode: 404,
+						ResponsePagePath: "/404.html",
+					}),
+					Match.objectLike({
+						ErrorCode: 404,
+						ResponseCode: 404,
+						ResponsePagePath: "/404.html",
+					}),
+				]),
+			}),
+		});
 	});
 
 	// biome-ignore lint/suspicious/noExplicitAny: CDK template is untyped


### PR DESCRIPTION
## Summary

Improve Envilder indexability by returning real 404 responses, consolidating trailing-slash URLs, and publishing crawler discovery signals.

Harden CloudFront redirect query serialization and make the shared static 404 response locale-aware without changing its HTTP 404 status.

## Changes

- Infrastructure: return the generated 404 page with HTTP 404, redirect extensionless URLs to their trailing-slash form, redirect legacy sitemap requests, and safely encode CloudFront query-object redirects.
- Website: add robots.txt, llms.txt, canonical and hreflang links, localized metadata, structured data, registry-driven locale URLs, and a locale-aware static 404 page.
- Tests: cover redirects, query serialization, typed CloudFront outcomes, and real error responses; update the synthesized stack snapshot.

## Testing

- [x] pnpm test
- [x] pnpm lint
- [x] pnpm --filter @envilder/website build

## Related

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized, styled 404 page with a home button.
  * Enhanced SEO outputs with improved canonical/alternate links, JSON-LD, and configurable robots/noindex behavior.
* **Bug Fixes**
  * Preserved query strings during CloudFront redirects, including legacy sitemap handling.
  * Improved trailing-slash and index routing for non-API directory-style requests.
  * Updated CloudFront error responses so both 403 and 404 serve `/404.html` with a 404 status.
* **Documentation**
  * Added `llms.txt` and `robots.txt` (sitemap index reference).
  * Refreshed translated metadata/page copy across supported languages.
* **Tests**
  * Expanded coverage for URL rewrite behavior and CloudFront error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->