### PR TITLE
feat(website): redesign cards with retro 8-bit pixel-art styling

### DIFF
--- a/src/website/src/components/FeaturesGrid.astro
+++ b/src/website/src/components/FeaturesGrid.astro
@@ -1,5 +1,6 @@
 ---
 import { useTranslations } from '../i18n/utils';
+import PixelSprite from './PixelSprite.astro';
 
 interface Props {
   lang?: string;
@@ -22,15 +23,18 @@ const t = useTranslations(lang);
     <div class="grid-2 highlights-grid">
       {t.features.highlights.map((f) => (
         <div class:list={['pixel-card', 'highlight-card', { 'feature-coming-soon': f.badge }]}>
-          <span class="pixel-icon">{f.icon}</span>
-          <div class="feature-title-row">
-            <h3>{f.title}</h3>
-            {f.badge && <span class="badge badge-small">{f.badge}</span>}
+          <div class="highlight-card-header">
+            <PixelSprite name={f.icon} />
+            <div class="feature-title-row">
+              <h3>{f.title}</h3>
+              {f.badge && <span class="badge badge-small">{f.badge}</span>}
+            </div>
           </div>
           <p>{f.description}</p>
         </div>
       ))}
     </div>
+
 
     <!-- Tier 2: Compact extras -->
     <div class="extras-section">
@@ -38,7 +42,7 @@ const t = useTranslations(lang);
       <div class="extras-grid">
         {t.features.extras.map((f) => (
           <div class="extra-item">
-            <span class="extra-icon">{f.icon}</span>
+            <PixelSprite name={f.icon} size={22} />
             <div class="extra-content">
               <strong>{f.title}</strong>
               <span class="extra-desc">{f.description}</span>
@@ -56,7 +60,7 @@ const t = useTranslations(lang);
   }
 
   .highlight-card h3 {
-    margin-bottom: var(--space-sm);
+    margin-bottom: 0;
     color: var(--color-text);
   }
 
@@ -65,8 +69,16 @@ const t = useTranslations(lang);
     line-height: 1.7;
   }
 
-  .highlight-card .pixel-icon {
-    font-size: 1.8rem;
+  .highlight-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .highlight-card-header :global(.pixel-sprite) {
+    margin-bottom: 0;
+    flex-shrink: 0;
   }
 
   .feature-title-row {
@@ -77,8 +89,8 @@ const t = useTranslations(lang);
   }
 
   .feature-coming-soon {
-    border-style: dashed;
     opacity: 0.85;
+    filter: grayscale(0.4);
   }
 
   .badge-small {
@@ -95,7 +107,7 @@ const t = useTranslations(lang);
     font-size: 0.7rem;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--color-accent);
+    color: var(--color-primary);
     margin-bottom: var(--space-lg);
   }
 
@@ -124,10 +136,10 @@ const t = useTranslations(lang);
     padding: var(--space-sm) 0;
   }
 
-  .extra-icon {
-    font-size: 1.1rem;
-    flex-shrink: 0;
+  .extra-item :global(.pixel-sprite) {
+    margin-bottom: 0;
     margin-top: 2px;
+    flex-shrink: 0;
   }
 
   .extra-content {

--- a/src/website/src/components/GetStarted.astro
+++ b/src/website/src/components/GetStarted.astro
@@ -1,5 +1,6 @@
 ---
 import { useTranslations } from '../i18n/utils';
+import CodeBlock from './CodeBlock.astro';
 import TerminalMockup from './TerminalMockup.astro';
 
 interface Props {
@@ -35,16 +36,16 @@ const t = useTranslations(lang);
           <h3>{t.getStarted.install}</h3>
           <div class="install-options">
             <div class="install-option">
-              <span class="install-label">pnpm</span>
-              <code class="install-code">pnpm add -g envilder</code>
+              <span class="install-label">npx</span>
+              <code class="install-code">npx envilder --map=envilder.json --envfile=.env</code>
             </div>
             <div class="install-option">
               <span class="install-label">npm</span>
               <code class="install-code">npm install -g envilder</code>
             </div>
             <div class="install-option">
-              <span class="install-label">npx</span>
-              <code class="install-code">npx envilder --help</code>
+              <span class="install-label">pnpm</span>
+              <code class="install-code">pnpm add -g envilder</code>
             </div>
           </div>
         </div>
@@ -62,14 +63,6 @@ const t = useTranslations(lang);
       <div class="getstarted-terminal">
         <TerminalMockup title={t.getStarted.terminalTitle}>
           <span class="line">
-            <span class="comment">{t.getStarted.commentInstall}</span>
-          </span>
-          <span class="line">
-            <span class="prompt">$</span>
-            <span class="command"> npm install -g envilder</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
             <span class="comment">{t.getStarted.commentCreate}</span>
           </span>
           <span class="line">
@@ -80,62 +73,51 @@ const t = useTranslations(lang);
           </span>
           <span class="line">&nbsp;</span>
           <span class="line">
-            <span class="comment">{t.getStarted.commentPull}</span>
-          </span>
-          <span class="line">
-            <span class="prompt">$</span><span class="command"> envilder</span><span class="flag"> --map</span><span class="command">=envilder.json</span><span class="flag"> --envfile</span><span class="command">=.env</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
-            <span class="highlight">✔</span>
-            <span class="output">{t.getStarted.doneMessage}</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
             <span class="comment">{t.getStarted.commentPush}</span>
           </span>
           <span class="line">
-            <span class="prompt">$</span><span class="command"> envilder</span><span class="flag"> --push</span><span class="flag"> --key</span><span class="command">=API_KEY</span><span class="flag"> --value</span><span class="command">=sk_live_abc123</span><span class="flag"> --secret-path</span><span class="command">=/app/api-key</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
-            <span class="highlight">✔</span>
-            <span class="output">{t.getStarted.pushSuccess}</span>
+            <span class="prompt">$</span><span class="command"> npx envilder</span><span class="flag"> --push</span><span class="flag"> --key</span><span class="command">=API_KEY</span><span class="flag"> --value</span><span class="command">=sk_live_abc123</span><span class="flag"> --secret-path</span><span class="command">=/app/api-key</span>
           </span>
         </TerminalMockup>
 
-        <TerminalMockup title={t.getStarted.sdkTerminalTitle}>
-          <span class="line">
-            <span class="comment">{t.getStarted.sdkComment1}</span>
-          </span>
-          <span class="line">
-            <span class="prompt">$</span><span class="command"> pip install envilder</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
-            <span class="comment">{t.getStarted.sdkComment2}</span>
-          </span>
-          <span class="line">
-            <span class="command"> from envilder import Envilder</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
-            <span class="command"> Envilder.load("envilder.json")</span>
-          </span>
-          <span class="line">&nbsp;</span>
-          <span class="line">
-            <span class="comment">{t.getStarted.sdkComment3}</span>
-          </span>
-          <span class="line">
-            <span class="command"> db_pass = os.environ["DB_PASSWORD"]</span>
-          </span>
-        </TerminalMockup>
+        <CodeBlock
+          lang="python"
+          filename="app.py"
+          code={`from envilder import Envilder\n\nEnvilder.load("envilder.json")\n\n${t.getStarted.sdkComment3}\napi_key = os.environ["API_KEY"]`}
+        />
+        <a
+          href="https://github.com/macalbert/envilder/tree/main/examples/sdk"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="sdk-example-link"
+        >
+          {t.getStarted.sdkExampleLink} →
+        </a>
       </div>
     </div>
   </div>
 </section>
 
 <style>
+  .getstarted-terminal {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .sdk-example-link {
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--color-primary);
+    text-decoration: none;
+    transition: opacity var(--transition-fast);
+  }
+
+  .sdk-example-link:hover {
+    opacity: 0.7;
+  }
+
   .getstarted-grid {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/website/src/components/GetStarted.astro
+++ b/src/website/src/components/GetStarted.astro
@@ -83,7 +83,7 @@ const t = useTranslations(lang);
         <CodeBlock
           lang="python"
           filename="app.py"
-          code={`from envilder import Envilder\n\nEnvilder.load("envilder.json")\n\n${t.getStarted.sdkComment3}\napi_key = os.environ["API_KEY"]`}
+          code={`import os\n\nfrom envilder import Envilder\n\nEnvilder.load("envilder.json")\n\n${t.getStarted.sdkComment3}\napi_key = os.environ["API_KEY"]`}
         />
         <a
           href="https://github.com/macalbert/envilder/tree/main/examples/sdk"

--- a/src/website/src/components/Governance.astro
+++ b/src/website/src/components/Governance.astro
@@ -57,19 +57,11 @@ const t = useTranslations(lang);
   }
 
   .governance-card {
-    border-color: var(--color-accent);
-  }
-
-  .governance-card::before {
-    border-color: var(--color-accent);
+    background: var(--color-accent);
   }
 
   .governance-card:hover {
-    border-color: var(--color-accent);
-    box-shadow: 4px 4px 0 rgba(138, 154, 108, 0.4);
-  }
-
-  .governance-card:hover::before {
-    border-color: var(--color-accent);
+    background: var(--color-accent);
+    filter: drop-shadow(4px 4px 0 rgba(138, 154, 108, 0.6));
   }
 </style>

--- a/src/website/src/components/PixelSprite.astro
+++ b/src/website/src/components/PixelSprite.astro
@@ -1,0 +1,139 @@
+---
+import type { PixelSpriteName } from '../i18n/types';
+
+// Hand-authored 8x8-ish pixel grids, true to the original Game Boy tile size.
+interface Props {
+  name: PixelSpriteName;
+  size?: number;
+}
+
+const { name, size = 34 } = Astro.props;
+
+const SPRITES: Record<PixelSpriteName, string[]> = {
+  skull: [
+    '..SSSS..',
+    '.SSSSSS.',
+    'SSSSSSSS',
+    'S..SS..S',
+    'SSSSSSSS',
+    '.SSSSSS.',
+    '.S.SS.S.',
+  ],
+  lock: [
+    '..SSSS..',
+    '.S....S.',
+    '.S....S.',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    'SS.SS.SS',
+    'SSSSSSSS',
+    '.SSSSSS.',
+  ],
+  snail: [
+    '......SS..',
+    '.....SSSS.',
+    '....SSSSSS',
+    'S.S..SSSSS',
+    '.S...SSSSS',
+    '..SSSSSSSS',
+    '.SSSSSSSS.',
+  ],
+  brick: [
+    'SSS.SSS.',
+    'SSS.SSS.',
+    '........',
+    '.SSS.SSS',
+    '.SSS.SSS',
+    '........',
+    'SSS.SSS.',
+    'SSS.SSS.',
+  ],
+  clipboard: [
+    '..SSSS..',
+    'SSSSSSSS',
+    'S......S',
+    'S.SSSS.S',
+    'S......S',
+    'S.SSSS.S',
+    'S......S',
+    'SSSSSSSS',
+  ],
+  refresh: [
+    '..SSSSS.',
+    '.S....SS',
+    'S......S',
+    'S......S',
+    'S......S',
+    'S......S',
+    'SS....S.',
+    '.SSSSS..',
+  ],
+  cloud: [
+    '...SS...',
+    '..SSSSS.',
+    '.SSSSSSS',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    '.SSSSSS.',
+  ],
+  gear: [
+    '..SSSS..',
+    'S.SSSS.S',
+    '.SSSSSS.',
+    'SS.SS.SS',
+    'SS.SS.SS',
+    '.SSSSSS.',
+    'S.SSSS.S',
+    '..SSSS..',
+  ],
+  plug: [
+    '.S...S..',
+    '.S...S..',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    '.SSSSSS.',
+    '...SS...',
+    '...SS...',
+  ],
+  chart: [
+    '......S.',
+    '......S.',
+    '....S.S.',
+    '....S.S.',
+    '..S.S.S.',
+    '..S.S.S.',
+    '..S.S.S.',
+    'SSSSSSSS',
+  ],
+  person: [
+    '..SSSS..',
+    '.SSSSSS.',
+    '.SSSSSS.',
+    '..SSSS..',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    'SSSSSSSS',
+    'SSSSSSSS',
+  ],
+};
+
+const grid = SPRITES[name];
+const cols = grid[0].length;
+const rows = grid.length;
+const cells = grid.flatMap((row, y) =>
+  [...row].flatMap((cell, x) => (cell === 'S' ? [{ x, y }] : [])),
+);
+---
+
+<svg
+  class="pixel-sprite"
+  width={size}
+  height={(size / cols) * rows}
+  viewBox={`0 0 ${cols} ${rows}`}
+  fill="currentColor"
+  shape-rendering="crispEdges"
+  aria-hidden="true"
+>
+  {cells.map(({ x, y }) => <rect x={x} y={y} width="1" height="1" />)}
+</svg>

--- a/src/website/src/components/ProblemSolution.astro
+++ b/src/website/src/components/ProblemSolution.astro
@@ -1,5 +1,6 @@
 ---
 import { useTranslations } from '../i18n/utils';
+import PixelSprite from './PixelSprite.astro';
 
 interface Props {
   lang?: string;
@@ -21,8 +22,10 @@ const t = useTranslations(lang);
     <div class="grid-3 problems-grid">
       {t.problemSolution.problems.map((p) => (
         <div class="pixel-card problem-card">
-          <span class="pixel-icon">{p.icon}</span>
-          <h3>{p.title}</h3>
+          <div class="problem-card-header">
+            <PixelSprite name={p.icon} />
+            <h3>{p.title}</h3>
+          </div>
           <p>{p.description}</p>
         </div>
       ))}
@@ -32,25 +35,29 @@ const t = useTranslations(lang);
 
 <style>
   .problem-card {
-    border-color: var(--color-error);
-  }
-
-  .problem-card::before {
-    border-color: var(--color-error);
+    background: var(--color-primary-dim);
   }
 
   .problem-card:hover {
-    border-color: var(--color-error);
-    box-shadow: 4px 4px 0 rgba(160, 80, 80, 0.35);
-  }
-
-  .problem-card:hover::before {
-    border-color: var(--color-error);
+    background: var(--color-primary-dim);
+    filter: drop-shadow(4px 4px 0 rgba(76, 175, 80, 0.6));
   }
 
   .pixel-card h3 {
-    margin-bottom: var(--space-sm);
+    margin-bottom: 0;
     color: var(--color-text);
+  }
+
+  .problem-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-bottom: var(--space-sm);
+  }
+
+  .problem-card-header :global(.pixel-sprite) {
+    margin-bottom: 0;
+    flex-shrink: 0;
   }
 
   .pixel-card p {

--- a/src/website/src/components/TerminalMockup.astro
+++ b/src/website/src/components/TerminalMockup.astro
@@ -86,12 +86,6 @@ const { title = 'bash' } = Astro.props;
     font-weight: 700;
   }
 
-  .terminal-body :global(.prompt)::before {
-    content: "envilder ~ ";
-    color: var(--term-path);
-    font-weight: 400;
-  }
-
   .terminal-body :global(.command) {
     color: var(--term-text);
   }

--- a/src/website/src/i18n/ca.ts
+++ b/src/website/src/i18n/ca.ts
@@ -83,19 +83,19 @@ export const ca: Translations = {
       'Cada equip, cada etapa, cada runtime gestiona els secrets de forma diferent. Sense estàndard. Sense consistència. Sense confiança.',
     problems: [
       {
-        icon: '💀',
+        icon: 'skull',
         title: 'Fragmentada entre eines',
         description:
           "L'entorn local utilitza fitxers .env. CI/CD llegeix d'integracions amb vaults. Producció té el seu propi mètode. Mateixa app, diferents fluxos de configuració a tot arreu.",
       },
       {
-        icon: '📨',
+        icon: 'lock',
         title: 'Secrets compartits per canals insegurs',
         description:
           'Claus API enviades per Slack, fitxers .env als repositoris, pàgines wiki amb credencials en text pla. Un incident de seguretat esperant a passar.',
       },
       {
-        icon: '🐌',
+        icon: 'snail',
         title: 'El desfasament de configuració és inevitable',
         description:
           'Sense una font única de veritat sobre quins secrets necessita una app. Dev, staging i producció es desincronitzen. Els desplegaments fallen. Ningú sap quina config és la correcta.',
@@ -152,25 +152,25 @@ export const ca: Translations = {
       'Envilder és una capa de resolució sobre el teu gestor de secrets existent. Els secrets es queden al teu núvol. El mapeig JSON és només el contracte que manté cada entorn consistent.',
     highlights: [
       {
-        icon: '🧱',
+        icon: 'brick',
         title: 'Zero infraestructura',
         description:
           'Sense servidors, sense proxies, sense SaaS intermediari. Construït sobre AWS SSM i Azure Key Vault, serveis que ja utilitzes i pagues.',
       },
       {
-        icon: '📋',
+        icon: 'clipboard',
         title: 'Un fitxer, tots els secrets',
         description:
           'Un sol contracte JSON defineix cada secret per a cada entorn. Versionat a Git, revisable en PRs, comparable. El teu equip revisa canvis de secrets al mateix PR que el codi.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Rotació de secrets segura',
         description:
           'Rota valors a AWS SSM o Azure Key Vault. Cada consumidor (local, CI/CD i runtime) resol el nou valor automàticament. Sense reescriure .env, sense canvis als pipelines.',
       },
       {
-        icon: '☁️',
+        icon: 'cloud',
         title: 'Multi-Cloud, sense lock-in',
         description:
           "AWS SSM, Azure Key Vault, GCP Secret Manager (pròximament). Canvia de proveïdor sense modificar el codi de l'app. El teu núvol, les teves regles.",
@@ -179,37 +179,37 @@ export const ca: Translations = {
     extrasTitle: 'També inclou',
     extras: [
       {
-        icon: '⚙️',
+        icon: 'gear',
         title: 'GitHub Action',
         description:
           'Obté secrets en workflows CI/CD. Mateix mapeig, zero intervenció manual.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Sincronització bidireccional',
         description:
           'Obté a .env o puja valors .env al teu proveïdor al núvol via CLI.',
       },
       {
-        icon: '🔌',
+        icon: 'plug',
         title: 'Els secrets no toquen disc',
         description:
           "SDKs de runtime carreguen secrets directament a memòria a l'inici de l'app. Sense fitxers .env escrits a disc.",
       },
       {
-        icon: '🔒',
+        icon: 'lock',
         title: 'IAM i RBAC natiu',
         description:
           "Polítiques IAM d'AWS o RBAC d'Azure. Sense capa d'auth extra.",
       },
       {
-        icon: '📊',
+        icon: 'chart',
         title: 'Traçabilitat completa',
         description:
           'Cada accés registrat a CloudTrail o Azure Monitor automàticament.',
       },
       {
-        icon: '👤',
+        icon: 'person',
         title: 'Suport de perfils AWS',
         description:
           'Canvia entre perfils AWS CLI per a configuracions multi-compte.',
@@ -421,19 +421,13 @@ export const ca: Translations = {
     quickStart: 'Inici ràpid',
     step1:
       "Crea un envilder.json que mapegi variables d'entorn a rutes de secrets",
-    step2: 'Executa envilder --map=envilder.json --envfile=.env',
+    step2: 'Executa npx envilder --map=envilder.json --envfile=.env',
     step3: 'El teu fitxer .env està llest ✔',
     terminalTitle: 'Inici ràpid',
-    commentInstall: '# Instal·lar globalment',
     commentCreate: '# Crear fitxer de mapeig',
-    commentPull: '# Obtenir secrets',
     commentPush: '# Pujar un secret',
-    doneMessage: ' Fet! Fitxer .env generat.',
-    pushSuccess: ' Secret pujat correctament.',
-    sdkTerminalTitle: 'Runtime SDK (Python)',
-    sdkComment1: "# Instal·lar l'SDK",
-    sdkComment2: "# Carregar secrets a l'inici",
     sdkComment3: '# Els secrets ja són a os.environ',
+    sdkExampleLink: 'Veure més exemples a GitHub',
   },
   footer: {
     tagline:

--- a/src/website/src/i18n/en.ts
+++ b/src/website/src/i18n/en.ts
@@ -83,19 +83,19 @@ export const en: Translations = {
       'Every team, every stage, every runtime handles secrets differently. No standard. No consistency. No confidence.',
     problems: [
       {
-        icon: '💀',
+        icon: 'skull',
         title: 'Fragmented across tools',
         description:
           'Local dev uses .env files. CI/CD reads from vault integrations. Production has its own method. Same app, different configuration workflows everywhere.',
       },
       {
-        icon: '📨',
+        icon: 'lock',
         title: 'Secrets shared through unsafe channels',
         description:
           'API keys sent over Slack, .env files committed to repos, wiki pages with plain-text credentials. A security incident waiting to happen.',
       },
       {
-        icon: '🐌',
+        icon: 'snail',
         title: 'Configuration drift is inevitable',
         description:
           'No single source of truth for what secrets an app needs. Dev, staging, and production desync. Deployments fail. Nobody knows which config is correct.',
@@ -152,25 +152,25 @@ export const en: Translations = {
       'Envilder is a resolution layer over your existing secret manager. Secrets stay in your cloud. The JSON mapping is just the contract that keeps every environment consistent.',
     highlights: [
       {
-        icon: '🧱',
+        icon: 'brick',
         title: 'Zero Infrastructure',
         description:
           'No servers, no proxies, no SaaS middleman. Built on AWS SSM and Azure Key Vault, services you already use and pay for.',
       },
       {
-        icon: '📋',
+        icon: 'clipboard',
         title: 'One File, All Secrets',
         description:
           'A single JSON contract defines every secret for every environment. Git-versioned, PR-reviewable, diff-able. Your team reviews secret changes in the same PR as the code.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Safe Secret Rotation',
         description:
           'Rotate values in AWS SSM or Azure Key Vault. Every consumer (local, CI/CD, and runtime) resolves the new value automatically. No .env rewrites, no pipeline changes.',
       },
       {
-        icon: '☁️',
+        icon: 'cloud',
         title: 'Multi-Cloud, No Lock-in',
         description:
           'AWS SSM, Azure Key Vault, GCP Secret Manager (coming soon). Switch providers without changing your app code. Your cloud, your rules.',
@@ -179,37 +179,37 @@ export const en: Translations = {
     extrasTitle: 'Also included',
     extras: [
       {
-        icon: '⚙️',
+        icon: 'gear',
         title: 'GitHub Action',
         description:
           'Pull secrets in CI/CD workflows. Same mapping, zero manual intervention.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Bidirectional Sync',
         description:
           'Pull to .env or push .env values back to your cloud provider via CLI.',
       },
       {
-        icon: '🔌',
+        icon: 'plug',
         title: 'Secrets Never Touch Disk',
         description:
           'Runtime SDKs load secrets directly into memory at app startup. No .env files written to disk.',
       },
       {
-        icon: '🔒',
+        icon: 'lock',
         title: 'Native IAM & RBAC',
         description:
           'AWS IAM policies or Azure RBAC. No extra auth layer needed.',
       },
       {
-        icon: '📊',
+        icon: 'chart',
         title: 'Full Audit Trail',
         description:
           'Every access logged in CloudTrail or Azure Monitor automatically.',
       },
       {
-        icon: '👤',
+        icon: 'person',
         title: 'AWS Profile Support',
         description:
           'Switch between AWS CLI profiles for multi-account setups.',
@@ -420,19 +420,13 @@ export const en: Translations = {
     install: 'Install',
     quickStart: 'Quick start',
     step1: 'Create an envilder.json mapping env vars to secret paths',
-    step2: 'Run envilder --map=envilder.json --envfile=.env',
+    step2: 'Run npx envilder --map=envilder.json --envfile=.env',
     step3: 'Your .env file is ready ✔',
     terminalTitle: 'Quick start',
-    commentInstall: '# Install globally',
     commentCreate: '# Create mapping file',
-    commentPull: '# Pull secrets',
     commentPush: '# Push a secret',
-    doneMessage: ' Done! .env file generated.',
-    pushSuccess: ' Secret pushed successfully.',
-    sdkTerminalTitle: 'Runtime SDK (Python)',
-    sdkComment1: '# Install the SDK',
-    sdkComment2: '# Load secrets at startup',
     sdkComment3: '# Secrets are now in os.environ',
+    sdkExampleLink: 'View more examples on GitHub',
   },
   footer: {
     tagline:

--- a/src/website/src/i18n/es.ts
+++ b/src/website/src/i18n/es.ts
@@ -83,19 +83,19 @@ export const es: Translations = {
       'Cada equipo, cada etapa, cada runtime gestiona los secretos de forma diferente. Sin estándar. Sin consistencia. Sin confianza.',
     problems: [
       {
-        icon: '💀',
+        icon: 'skull',
         title: 'Fragmentada entre herramientas',
         description:
           'El entorno local usa archivos .env. CI/CD lee de integraciones con vaults. Producción tiene su propio método. Misma app, diferentes flujos de configuración.',
       },
       {
-        icon: '📨',
+        icon: 'lock',
         title: 'Secretos compartidos por canales inseguros',
         description:
           'Claves API enviadas por Slack, archivos .env en repositorios, páginas wiki con credenciales en texto plano. Un incidente de seguridad esperando a ocurrir.',
       },
       {
-        icon: '🐌',
+        icon: 'snail',
         title: 'El desfase de configuración es inevitable',
         description:
           'Sin una fuente única de verdad sobre qué secretos necesita una app. Dev, staging y producción se desincronizan. Los despliegues fallan. Nadie sabe qué config es la correcta.',
@@ -152,25 +152,25 @@ export const es: Translations = {
       'Envilder es una capa de resolución sobre tu gestor de secretos existente. Los secretos se quedan en tu nube. El mapeo JSON es solo el contrato que mantiene cada entorno consistente.',
     highlights: [
       {
-        icon: '🧱',
+        icon: 'brick',
         title: 'Cero infraestructura',
         description:
           'Sin servidores, sin proxies, sin SaaS intermediario. Construido sobre AWS SSM y Azure Key Vault, servicios que ya usas y pagas.',
       },
       {
-        icon: '📋',
+        icon: 'clipboard',
         title: 'Un archivo, todos los secretos',
         description:
           'Un solo contrato JSON define cada secreto para cada entorno. Versionado en Git, revisable en PRs, comparable. Tu equipo revisa cambios de secretos en el mismo PR que el código.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Rotación de secretos segura',
         description:
           'Rota valores en AWS SSM o Azure Key Vault. Cada consumidor (local, CI/CD y runtime) resuelve el nuevo valor automáticamente. Sin reescribir .env, sin cambios en los pipelines.',
       },
       {
-        icon: '☁️',
+        icon: 'cloud',
         title: 'Multi-Cloud, sin lock-in',
         description:
           'AWS SSM, Azure Key Vault, GCP Secret Manager (próximamente). Cambia de proveedor sin modificar el código de tu app. Tu nube, tus reglas.',
@@ -179,37 +179,37 @@ export const es: Translations = {
     extrasTitle: 'También incluye',
     extras: [
       {
-        icon: '⚙️',
+        icon: 'gear',
         title: 'GitHub Action',
         description:
           'Obtiene secretos en workflows CI/CD. Mismo mapeo, cero intervención manual.',
       },
       {
-        icon: '🔄',
+        icon: 'refresh',
         title: 'Sincronización bidireccional',
         description:
           'Obtiene en .env o sube valores .env a tu proveedor en la nube vía CLI.',
       },
       {
-        icon: '🔌',
+        icon: 'plug',
         title: 'Los secretos no tocan disco',
         description:
           'SDKs de runtime cargan secretos directamente en memoria al iniciar la app. Sin archivos .env escritos a disco.',
       },
       {
-        icon: '🔒',
+        icon: 'lock',
         title: 'IAM y RBAC nativo',
         description:
           'Políticas IAM de AWS o RBAC de Azure. Sin capa de auth extra.',
       },
       {
-        icon: '📊',
+        icon: 'chart',
         title: 'Trazabilidad completa',
         description:
           'Cada acceso registrado en CloudTrail o Azure Monitor automáticamente.',
       },
       {
-        icon: '👤',
+        icon: 'person',
         title: 'Soporte de perfiles AWS',
         description:
           'Cambia entre perfiles AWS CLI para configuraciones multi-cuenta.',
@@ -421,19 +421,13 @@ export const es: Translations = {
     quickStart: 'Inicio rápido',
     step1:
       'Crea un envilder.json que mapee variables de entorno a rutas de secretos',
-    step2: 'Ejecuta envilder --map=envilder.json --envfile=.env',
+    step2: 'Ejecuta npx envilder --map=envilder.json --envfile=.env',
     step3: 'Tu archivo .env está listo ✔',
     terminalTitle: 'Inicio rápido',
-    commentInstall: '# Instalar globalmente',
     commentCreate: '# Crear archivo de mapeo',
-    commentPull: '# Obtener secretos',
     commentPush: '# Subir un secreto',
-    doneMessage: ' ¡Hecho! Archivo .env generado.',
-    pushSuccess: ' Secreto subido correctamente.',
-    sdkTerminalTitle: 'Runtime SDK (Python)',
-    sdkComment1: '# Instalar el SDK',
-    sdkComment2: '# Cargar secretos al iniciar',
     sdkComment3: '# Los secretos ya están en os.environ',
+    sdkExampleLink: 'Ver más ejemplos en GitHub',
   },
   footer: {
     tagline:

--- a/src/website/src/i18n/types.ts
+++ b/src/website/src/i18n/types.ts
@@ -56,8 +56,21 @@ export interface TrustTranslations {
   label: string;
 }
 
+export type PixelSpriteName =
+  | 'skull'
+  | 'lock'
+  | 'snail'
+  | 'brick'
+  | 'clipboard'
+  | 'refresh'
+  | 'cloud'
+  | 'gear'
+  | 'plug'
+  | 'chart'
+  | 'person';
+
 export interface ProblemItem {
-  icon: string;
+  icon: PixelSpriteName;
   title: string;
   description: string;
 }
@@ -94,14 +107,14 @@ export interface HowItWorksTranslations {
 }
 
 export interface FeatureItem {
-  icon: string;
+  icon: PixelSpriteName;
   title: string;
   description: string;
   badge?: string;
 }
 
 export interface FeatureExtraItem {
-  icon: string;
+  icon: PixelSpriteName;
   title: string;
   description: string;
 }
@@ -217,16 +230,10 @@ export interface GetStartedTranslations {
   step2: string;
   step3: string;
   terminalTitle: string;
-  commentInstall: string;
   commentCreate: string;
-  commentPull: string;
   commentPush: string;
-  doneMessage: string;
-  pushSuccess: string;
-  sdkTerminalTitle: string;
-  sdkComment1: string;
-  sdkComment2: string;
   sdkComment3: string;
+  sdkExampleLink: string;
 }
 
 export interface FooterTranslations {

--- a/src/website/src/styles/global.css
+++ b/src/website/src/styles/global.css
@@ -343,36 +343,98 @@ pre code,
   box-shadow: none;
 }
 
-/* ── Cards (pixel-bordered) ───────────────────────────── */
+/* ── Cards (retro game window, stepped pixel corners) ── */
+/*
+ * Classic RPG dialog-box construction: the element's OWN background is
+ * the frame color, clipped into a stepped/staircase silhouette. ::before
+ * is inset by --pixel-frame (box shrinks, but reuses the SAME --pixel-step
+ * for its own clip-path) and painted in the surface color, leaving a
+ * uniform --pixel-frame-wide pixel border on all four corners. Reusing a
+ * reduced step there would pinch the border to zero width exactly at each
+ * notch's reflex vertex. ::after draws an inset groove line (the "bezel")
+ * that follows the same inner stepped silhouette.
+ */
 .pixel-card {
-  background: var(--color-surface);
-  border: 2px solid var(--color-border);
-  padding: var(--space-xl);
+  --pixel-step: 14px;
+  --pixel-frame: 6px;
   position: relative;
-  transition: all var(--transition-base);
+  background: var(--color-border-light);
+  padding: var(--space-xl);
+  clip-path: polygon(
+    0 var(--pixel-step),
+    var(--pixel-step) var(--pixel-step),
+    var(--pixel-step) 0,
+    calc(100% - var(--pixel-step)) 0,
+    calc(100% - var(--pixel-step)) var(--pixel-step),
+    100% var(--pixel-step),
+    100% calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) 100%,
+    var(--pixel-step) 100%,
+    var(--pixel-step) calc(100% - var(--pixel-step)),
+    0 calc(100% - var(--pixel-step))
+  );
+  transition:
+    transform var(--transition-base),
+    filter var(--transition-base),
+    background var(--transition-base);
 }
 
 .pixel-card:hover {
-  border-color: var(--color-primary);
-  box-shadow: var(--pixel-shadow-primary);
-  transform: translate(-2px, -2px);
+  transform: translate(-3px, -3px);
+  filter: drop-shadow(4px 4px 0 var(--color-primary-dim));
+  background: var(--color-primary);
 }
 
-/* corner notch decoration */
+/* interior surface fill, inset by the frame thickness */
+/* negative z-index: must paint above the host's own frame background
+   but below the card's in-flow text content (h3/p), which paint in a
+   later paint-order step than negative-z-index positioned children */
 .pixel-card::before {
   content: "";
   position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 12px;
-  height: 12px;
-  background: var(--color-bg);
-  border-left: 2px solid var(--color-border);
-  border-bottom: 2px solid var(--color-border);
+  z-index: -1;
+  inset: var(--pixel-frame);
+  background: var(--color-surface);
+  clip-path: polygon(
+    0 var(--pixel-step),
+    var(--pixel-step) var(--pixel-step),
+    var(--pixel-step) 0,
+    calc(100% - var(--pixel-step)) 0,
+    calc(100% - var(--pixel-step)) var(--pixel-step),
+    100% var(--pixel-step),
+    100% calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) 100%,
+    var(--pixel-step) 100%,
+    var(--pixel-step) calc(100% - var(--pixel-step)),
+    0 calc(100% - var(--pixel-step))
+  );
 }
 
-.pixel-card:hover::before {
-  border-color: var(--color-primary);
+/* inner bezel groove, follows the same stepped silhouette */
+.pixel-card::after {
+  content: "";
+  position: absolute;
+  inset: var(--pixel-frame);
+  clip-path: polygon(
+    0 var(--pixel-step),
+    var(--pixel-step) var(--pixel-step),
+    var(--pixel-step) 0,
+    calc(100% - var(--pixel-step)) 0,
+    calc(100% - var(--pixel-step)) var(--pixel-step),
+    100% var(--pixel-step),
+    100% calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) calc(100% - var(--pixel-step)),
+    calc(100% - var(--pixel-step)) 100%,
+    var(--pixel-step) 100%,
+    var(--pixel-step) calc(100% - var(--pixel-step)),
+    0 calc(100% - var(--pixel-step))
+  );
+  box-shadow:
+    inset 0 0 0 2px var(--color-bg),
+    inset 0 0 0 4px var(--color-border-light);
+  pointer-events: none;
 }
 
 /* ── Pixel icon (8-bit style emoji replacement) ───────── */
@@ -394,6 +456,14 @@ pre code,
   text-shadow:
     1px 0 0 rgba(107, 104, 96, 0.2),
     0 1px 0 rgba(107, 104, 96, 0.2);
+}
+
+/* ── Pixel sprite (hand-authored 8-bit icon, real pixel art) ─ */
+.pixel-sprite {
+  display: inline-block;
+  margin-bottom: var(--space-md);
+  color: var(--color-primary);
+  filter: drop-shadow(2px 2px 0 rgba(0, 0, 0, 0.35));
 }
 
 /* ── Badge / Tag ──────────────────────────────────────── */
@@ -507,15 +577,6 @@ pre code,
 
   .section {
     padding: var(--space-3xl) 0;
-  }
-
-  .pixel-card::before {
-    display: none;
-  }
-
-  .pixel-card:hover {
-    transform: none;
-    box-shadow: var(--pixel-shadow-primary);
   }
 }
 

--- a/src/website/src/styles/global.css
+++ b/src/website/src/styles/global.css
@@ -357,6 +357,10 @@ pre code,
 .pixel-card {
   --pixel-step: 14px;
   --pixel-frame: 6px;
+
+  /* explicit stacking context: don't rely on clip-path implicitly creating
+     one for the ::before z-index: -1 surface layer to paint correctly */
+  isolation: isolate;
   position: relative;
   background: var(--color-border-light);
   padding: var(--space-xl);


### PR DESCRIPTION
## Summary

Redesigns the `.pixel-card` component used across the website (Problem/Solution, Features, Governance, 404) into an authentic retro 8-bit RPG dialog-window look, replaces emoji icons with hand-authored pixel-art sprites, and simplifies the Get Started terminal/code walkthrough to drop unnecessary install steps and better match the actual runnable Python example.

## Changes

- Redesigned `.pixel-card` in global.css into a stepped/staircase pixel-corner "retro game window" frame on all four corners, with a two-tone inset bezel groove, replacing the old single-corner notch decoration.
- Fixed a corner-pinch clip-path math bug where the inner surface fill's notch depth needs to match the outer frame's notch depth (not shrink by the frame width), otherwise the border collapses to zero width at each corner's reflex vertex.
- Fixed a paint-order bug where the surface-fill pseudo-element needs `z-index: -1` to render behind card text content instead of covering it.
- Fixed a leftover `@media (max-width: 640px)` rule that hid the (now load-bearing) `::before` surface-fill layer on narrow viewports, which exposed the raw frame-color background across the whole card on mobile.
- Replaced the red `--color-error` accent on problem cards with the Game Boy palette's `--color-primary-dim` to stay within the retro theme's 4-shade green palette.
- Added `PixelSprite.astro`: a reusable component rendering hand-authored 8x8 pixel-grid icons (skull, lock, snail, brick, clipboard, refresh, cloud, gear, plug, chart, person) via SVG `<rect>` elements colored with `currentColor`, replacing emoji + CSS-filter icons in ProblemSolution and FeaturesGrid (highlights and extras).
- Restructured ProblemSolution and FeaturesGrid highlight cards into an icon-left/title-right two-column header row instead of stacking the icon above the title.
- Simplified the GetStarted terminal walkthrough: switched from a required `npm install -g` step to `npx envilder` (no install needed), reordered push before pull, dropped the redundant push success confirmation line, and removed the tilde/project-name prefix from the terminal prompt.
- Replaced the small "Runtime SDK (Python)" terminal mockup with a proper `CodeBlock` (VS Code/editor-style tab with filename + language badge), matching the pattern already used in HowItWorks' SDK tabs.
- Added a "View more examples on GitHub" link pointing to the `examples/sdk` directory below the Python snippet.
- Removed now-unused i18n keys (`commentInstall`, `commentPull`, `doneMessage`, `pushSuccess`, `sdkTerminalTitle`, `sdkComment1`, `sdkComment2`) across en/ca/es locale files and `types.ts`.

## Testing

- [x] `pnpm test` passes (44 files, 357 tests)
- [x] `pnpm lint` passes (secretlint + biome + tsc)
- [x] Manual verification in the browser across retro/light themes and desktop/mobile viewports

## Related

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable pixel-art icon component and updated feature, problem, and extras cards to use named icons.
  * Included a Python SDK code example with a link to a repository.
* **Documentation**
  * Refreshed quick-start instructions and example text for `npx envilder` map + environment-file usage.
* **Style**
  * Reimplemented card styling as a stepped “retro game window” with updated hover behavior.
  * Adjusted highlights/extras/problem layout, icon spacing, and “coming soon” grayscale treatment.
  * Updated Governance card hover/background styling.
* **Bug Fixes**
  * Removed the hard-coded terminal prompt prefix styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->