### PR TITLE
ci(coverage): build website before running cli coverage tests

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -54,6 +54,9 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: 🏗️ Build website
+        run: pnpm --filter @envilder/website build
+
       - name: 🏎️ Run tests with coverage
         run: |
           mkdir -p output


### PR DESCRIPTION
## Problem

The `test-cli` job in `🏰 Star Castle Coverage` failed on the last push to `main`:

```text
The report file 'coverage/lcov.info' is invalid. File does not exist.
Error: Failed to execute ReportGenerator global tool
```

## Root cause

Commit `8c4be06e` (#470) added `tests/website/static-site.test.ts`, which reads built
output from `src/website/dist`. That PR added the website build to the root `test` and
`test:ci` scripts in `package.json`, but the `test-cli` job invokes `pnpm vitest run`
directly and never goes through those scripts.

Without `src/website/dist`, the SEO tests throw `ENOENT` and vitest never writes
`coverage/lcov.info`, so ReportGenerator has nothing to consume.

## Fix

Add a `🏗️ Build website` step before the coverage run in the `test-cli` job.

## Verification

- Reproduced locally by temporarily removing `src/website/dist`: the SEO tests fail with
  `ENOENT` and no `lcov.info` is produced.
- With the website built, `tests/website/` passes (54/54) and `lcov.info` is generated.
- Audited every workflow: `tests.yml` (`pnpm test:ci`) and `publish-npm.yml` (`pnpm test`)
  already build the website via the package scripts. The `test-iac` job only runs
  `tests/iac/`, which uses a `tmpDir` fixture rather than the real `dist`.
- `pnpm lint` passes.

## Trade-off

An alternative is to make the job call `pnpm test:ci` so there is a single definition of
"run the tests". That was not done here because the job needs fine-grained coverage flags
(`--exclude`, `--coverage.reportsDirectory`). Worth reconsidering if the two definitions
drift again.
