### PR TITLE
ci: fix coverage pipeline reliability and clear compiler warnings

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: 🏎️ Run tests with coverage
         run: |
+          set -o pipefail
           mkdir -p output
           pnpm vitest run --reporter=verbose \
             --exclude='tests/sdks/**' \
@@ -265,6 +266,7 @@ jobs:
 
       - name: 🏎️ Run tests with coverage
         run: |
+          set -o pipefail
           mkdir -p output
           cd tests/sdks/nodejs && pnpm vitest run --reporter=verbose --coverage 2>&1 | tee ../../../output/test-output.txt
         env:
@@ -319,6 +321,7 @@ jobs:
 
       - name: 🏎️ Run tests with coverage
         run: |
+          set -o pipefail
           mkdir -p output
           pnpm vitest run --reporter=verbose --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=coverage-iac --coverage.include='src/iac/**/*.ts' tests/iac/ 2>&1 | tee output/test-output.txt
 

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -131,6 +131,7 @@ jobs:
 
       - name: 🏎️ Run tests with coverage
         run: |
+          set -o pipefail
           mkdir -p output
           dotnet-coverage collect \
             "dotnet test src/sdks/dotnet/Envilder.sln --configuration Release --logger:console;verbosity=detailed" \
@@ -199,6 +200,7 @@ jobs:
 
       - name: 🏎️ Run tests with coverage
         run: |
+          set -o pipefail
           mkdir -p output
           cd tests/sdks/python && python -m pytest -v \
             --cov=envilder \

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["./**/*.ts"]
 }

--- a/src/website/src/i18n/utils.ts
+++ b/src/website/src/i18n/utils.ts
@@ -56,7 +56,9 @@ export function stripLocalePrefix(path: string) {
 export function localizedLanguages(path: string): readonly Lang[] {
   const { pathname } = splitPath(path);
   const normalizedPath = normalizePath(stripLocalePrefix(pathname));
-  const routeLanguages = localizedRoutes[normalizedPath];
+  const routeLanguages = Object.hasOwn(localizedRoutes, normalizedPath)
+    ? localizedRoutes[normalizedPath as keyof typeof localizedRoutes]
+    : undefined;
 
   return (routeLanguages ?? [defaultLang]) as readonly Lang[];
 }

--- a/tests/envilder/core/infrastructure/aws/AwsSsmSecretProvider.test.ts
+++ b/tests/envilder/core/infrastructure/aws/AwsSsmSecretProvider.test.ts
@@ -354,7 +354,7 @@ describe('AwsSsmSecretProvider (integration with LocalStack)', () => {
         Type: 'SecureString',
       }),
     );
-  }, 60_000);
+  }, 120_000);
 
   afterAll(async () => {
     await container.stop();

--- a/tests/sdks/dotnet/Infrastructure/Aws/AwsSsmSecretProviderTests.cs
+++ b/tests/sdks/dotnet/Infrastructure/Aws/AwsSsmSecretProviderTests.cs
@@ -15,7 +15,7 @@ public class AwsSsmSecretProviderTests
 		// Arrange
 		var ssmClient = Substitute.For<IAmazonSimpleSystemsManagement>();
 		ssmClient.GetParameterAsync(
-				Arg.Is<GetParameterRequest>(r => r.Name == "/Test/Token" && r.WithDecryption == true),
+				Arg.Is<GetParameterRequest>(r => r!.Name == "/Test/Token" && r.WithDecryption == true),
 				Arg.Any<CancellationToken>())
 			.Returns(new GetParameterResponse
 			{
@@ -54,7 +54,7 @@ public class AwsSsmSecretProviderTests
 		// Arrange
 		var ssmClient = Substitute.For<IAmazonSimpleSystemsManagement>();
 		ssmClient.GetParameterAsync(
-				Arg.Is<GetParameterRequest>(r => r.Name == "/Test/SyncToken" && r.WithDecryption == true),
+				Arg.Is<GetParameterRequest>(r => r!.Name == "/Test/SyncToken" && r.WithDecryption == true),
 				Arg.Any<CancellationToken>())
 			.Returns(new GetParameterResponse
 			{

--- a/tests/sdks/nodejs/infrastructure/aws/aws-ssm-secret-provider.test.ts
+++ b/tests/sdks/nodejs/infrastructure/aws/aws-ssm-secret-provider.test.ts
@@ -1,5 +1,8 @@
+import type { SSMClient } from '@aws-sdk/client-ssm';
 import { describe, expect, it, vi } from 'vitest';
 import { AwsSsmSecretProvider } from '../../../../../src/sdks/nodejs/src/infrastructure/aws/aws-ssm-secret-provider.js';
+
+const asSsmClient = (send: unknown) => ({ send }) as unknown as SSMClient;
 
 describe('AwsSsmSecretProvider', () => {
   it('Should_ReturnValues_When_ParametersExist', async () => {
@@ -11,7 +14,7 @@ describe('AwsSsmSecretProvider', () => {
       ],
       InvalidParameters: [],
     });
-    const mockClient = { send: mockSend };
+    const mockClient = asSsmClient(mockSend);
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act
@@ -29,7 +32,7 @@ describe('AwsSsmSecretProvider', () => {
       Parameters: [{ Name: '/app/db-url', Value: 'postgres://localhost' }],
       InvalidParameters: ['/app/missing'],
     });
-    const mockClient = { send: mockSend };
+    const mockClient = asSsmClient(mockSend);
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act
@@ -43,7 +46,8 @@ describe('AwsSsmSecretProvider', () => {
 
   it('Should_ReturnEmptyMap_When_NamesIsEmpty', async () => {
     // Arrange
-    const mockClient = { send: vi.fn() };
+    const mockSend = vi.fn();
+    const mockClient = asSsmClient(mockSend);
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act
@@ -51,7 +55,7 @@ describe('AwsSsmSecretProvider', () => {
 
     // Assert
     expect(actual.size).toBe(0);
-    expect(mockClient.send).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('Should_BatchRequests_When_MoreThanTenNames', async () => {
@@ -61,7 +65,7 @@ describe('AwsSsmSecretProvider', () => {
       Parameters: [],
       InvalidParameters: [],
     });
-    const mockClient = { send: mockSend };
+    const mockClient = asSsmClient(mockSend);
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act
@@ -73,7 +77,7 @@ describe('AwsSsmSecretProvider', () => {
 
   it('Should_ThrowError_When_SsmClientIsNull', () => {
     // Act
-    const act = () => new AwsSsmSecretProvider(null);
+    const act = () => new AwsSsmSecretProvider(null as unknown as SSMClient);
 
     // Assert
     expect(act).toThrow('ssmClient cannot be null');
@@ -81,7 +85,7 @@ describe('AwsSsmSecretProvider', () => {
 
   it('Should_ThrowError_When_AnyNameIsEmpty', async () => {
     // Arrange
-    const mockClient = { send: vi.fn() };
+    const mockClient = asSsmClient(vi.fn());
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act
@@ -98,7 +102,7 @@ describe('AwsSsmSecretProvider', () => {
     const error = new Error('AccessDenied');
     error.name = 'AccessDenied';
     const mockSend = vi.fn().mockRejectedValue(error);
-    const mockClient = { send: mockSend };
+    const mockClient = asSsmClient(mockSend);
     const sut = new AwsSsmSecretProvider(mockClient);
 
     // Act

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "rootDir": "..",
     "noEmit": true,
+    "target": "es2022",
+    "lib": ["es2022"],
     "module": "esnext",
     "moduleResolution": "bundler"
   },

--- a/tests/website/static-site.test.ts
+++ b/tests/website/static-site.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { localizedRoutes } from '../../src/website/src/i18n/localized-routes';
+import { localizedLanguages } from '../../src/website/src/i18n/utils';
 
 const siteUrl = 'https://envilder.com';
 const distDirectory = resolve(__dirname, '../../src/website/dist');
@@ -45,7 +45,7 @@ function getExpectedAlternateUrls(path: string): string[] {
   const route = localizedPath.endsWith('/')
     ? localizedPath
     : `${localizedPath}/`;
-  const languages = localizedRoutes[route];
+  const languages = localizedLanguages(route);
   const languageUrls = languages.map((language) =>
     language === 'en' ? `${siteUrl}${route}` : `${siteUrl}/${language}${route}`,
   );

--- a/tests/website/tsconfig.json
+++ b/tests/website/tsconfig.json
@@ -1,11 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../..",
-    "noEmit": true,
-    "module": "esnext",
-    "moduleResolution": "bundler"
-  },
+  "extends": "../tsconfig.json",
   "include": ["./**/*.ts", "../../src/website/src/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Problem

`test-cli` still failed after #472 with the same symptom:

```text
The report file 'coverage/lcov.info' is invalid. File does not exist.
Error: Failed to execute ReportGenerator global tool
```

Separately, CI surfaced two `CS8602` nullable-dereference warnings in the .NET SDK tests.

## Root cause

Two distinct issues, neither related to the website build fixed in #472 (all website
tests now pass).

**1. LocalStack hook timeout.** The `beforeAll` in `AwsSsmSecretProvider.test.ts`
(integration with LocalStack) allowed only 60s to pull and start the container:

```text
FAIL tests/envilder/core/infrastructure/aws/AwsSsmSecretProvider.test.ts
     > AwsSsmSecretProvider (integration with LocalStack)
Error: Hook timed out in 60000ms.
```

Every other container-starting hook in the repo already allows 120s
(`tests/sdks/nodejs/acceptance/*`, `e2e/cli.test.ts`, `e2e/gha.test.ts`). This suite was
the outlier. With the suite failing, vitest never wrote `coverage/lcov.info`, so
ReportGenerator had no input.

Note the run reported `364 passed | 4 skipped` — zero assertion failures. Only the
container startup hook timed out.

**2. Failure masked by `tee`.** The test step pipes vitest through `tee` without
`pipefail`, so the step exit code came from `tee`, not vitest. GitHub marked
`🏎️ Run tests with coverage` as successful even though vitest exited non-zero, and the
error only surfaced two steps later at ReportGenerator. That made the first
investigation point at the wrong cause.

**3. Compiler warnings and latent type errors.** The `Arg.Is<GetParameterRequest>`
lambda parameter is nullable under NSubstitute, so `r.Name` was a possibly-null
dereference in two tests. Sweeping every stack for the same class of problem surfaced
more type errors, all invisible to CI because **nothing type-checks the website,
`tests/`, `scripts/` or the SDK tests**: `pnpm lint` only covers the root tsconfig
(`src/**` minus website), and both vitest and `astro build` transpile without
type-checking.

## Fix

**CI reliability**

- Raise the LocalStack `beforeAll` timeout from 60s to 120s, matching every other
  container hook in the repo.
- Add `set -o pipefail` to the three test steps that pipe into `tee`, so a failing test
  run fails its own step instead of surfacing as a confusing downstream error.

**Warnings and type errors**

- `.NET`: use `r!.Name` in the two `Arg.Is<GetParameterRequest>` matchers.
- `tests/sdks/nodejs`: the SSM client test double was a bare `{ send }` object,
  structurally incompatible with `SSMClient`.
- `src/website` + `tests/website`: `localizedRoutes[path]` indexed a `const`-typed
  object with an arbitrary string. Guarded with `Object.hasOwn`, the same way
  `normalizeLang` already does; the test now reuses the typed `localizedLanguages()`
  helper instead of indexing the route map directly.
- `tests/tsconfig.json` inherited the `es2016` target from the root config, so the `/s`
  regex flag was rejected. `tests/website` now inherits from it rather than duplicating
  compiler options.
- `scripts/tsconfig.json` was missing `types: ["node"]`.

## Verification

| Check | Result |
| --- | --- |
| `dotnet build src/sdks/dotnet/Envilder.sln --no-incremental -warnaserror` | 0 warnings, 0 errors |
| `dotnet format --verify-no-changes` | clean |
| `tsc --noEmit` on all 9 tsconfigs (`.`, `tests`, `tests/website`, `src/website`, `src/sdks/nodejs`, `tests/sdks/nodejs`, `src/iac`, `tests/iac`, `scripts`) | 0 failing |
| `pnpm lint`, `pnpm format:check` | clean |
| `make check-sdk-python` (black + isort + mypy strict) | clean |
| `pnpm test` (full suite with coverage) | green |
| Website build + 54 website tests, 80 Node.js SDK tests, .NET SDK tests | green |

`src/sdks/go` and `src/sdks/java` contain only `.gitkeep`, nothing to check.

## Trade-offs

Raising a timeout treats the symptom, not container start time itself. It is the right
call here because the value was inconsistent with the rest of the suite rather than
tuned, and CI cold-pulls the LocalStack image. If startup keeps creeping up, the fix is
image caching in CI, not another bump.

The type errors are fixed but **not guarded against regression**: no workflow runs `tsc`
on those directories, so they can silently come back. Wiring `tsc --noEmit -p <dir>`
into the website and SDK workflows (and `TreatWarningsAsErrors` in the .NET
`Directory.Build.props`) is the durable fix, left out of this PR to keep the CI policy
change separate from the cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the LocalStack integration test setup timeout to improve reliability in slower test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
