### PR TITLE
fix(deps): synchronize tsx catalog lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,14 +119,14 @@ importers:
         specifier: ^12.0.4
         version: 12.1.0
       tsx:
-        specifier: 4.23.13
-        version: 4.23.13
+        specifier: 'catalog:'
+        version: 4.23.5
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
       vitest:
         specifier: 'catalog:'
-        version: 4.1.11(@types/node@26.1.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.13)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.1.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0))
 
   src/iac:
     dependencies:
@@ -5286,7 +5286,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.1.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@26.1.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -5304,6 +5304,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.13)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -7066,6 +7074,7 @@ snapshots:
       esbuild: 0.28.2
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   tsx@4.23.5:
     dependencies:
@@ -7213,6 +7222,21 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.9.0
 
+  vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.23.5
+      yaml: 2.9.0
+
   vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -7253,6 +7277,34 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
       vite: 8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.11(@types/node@26.1.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.6.1)(tsx@4.23.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1


### PR DESCRIPTION
## Summary

Synchronize the root `tsx` entry in `pnpm-lock.yaml` with the existing workspace catalog declaration. This restores frozen pnpm installations that were blocked by an importer specifier mismatch.

## Changes

- Regenerated the root importer with the repository-declared pnpm 11.10.0 so `tsx` uses `specifier: 'catalog:'` and resolves to catalog version `4.23.5`.
- Updated the pnpm-generated Vitest and Vite peer snapshots required by the root `tsx` resolution without changing manifests or introducing new package identities.

## Testing

- [x] `pnpm format` passes
- [x] `pnpm lint` passes
- [x] Fresh `pnpm install --frozen-lockfile --ignore-scripts` passes with pnpm 11.10.0 and leaves tracked content unchanged
- [ ] `pnpm test` passes locally; the full suite is blocked on this ARM64 Docker host because AMD64-emulated Lowkey Vault and LocalStack containers exceed or fail their startup lifecycle limits

## Related

Closes #510
